### PR TITLE
Bugfixes for ScrollController and improvements to compatibly with CupertinoApp/WidgetsApp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,6 @@
 
 ## [0.1.4] - Clean code and fix small bugs
 
-
+## [0.1.5] - Bugfixes
+- fix assertion in CupertinoBottomSheet and BottomSheetRoute when using the CupetinoApp or WidgetsApp as root
+- fix assertion when scrollController isn't used by the builder 

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -231,7 +231,8 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
   void _handleScrollUpdate(ScrollNotification notification) {
     if (notification.metrics.pixels <= notification.metrics.minScrollExtent) {
       //Check if listener is same from scrollController
-      if (_scrollController.position.pixels != notification.metrics.pixels) {
+      if (_scrollController.hasClients &&
+          _scrollController.position.pixels != notification.metrics.pixels) {
         return;
       }
       DragUpdateDetails dragDetails;

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -231,8 +231,9 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
   void _handleScrollUpdate(ScrollNotification notification) {
     if (notification.metrics.pixels <= notification.metrics.minScrollExtent) {
       //Check if listener is same from scrollController
-      if (_scrollController.hasClients &&
-          _scrollController.position.pixels != notification.metrics.pixels) {
+      if (!_scrollController.hasClients) return;
+
+      if (_scrollController.position.pixels != notification.metrics.pixels) {
         return;
       }
       DragUpdateDetails dragDetails;

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -32,17 +32,22 @@ class _ModalBottomSheet<T> extends StatefulWidget {
 }
 
 class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
-  String _getRouteLabel(MaterialLocalizations localizations) {
-    final platform = Theme.of(context).platform;
-    switch (platform) {
-      case TargetPlatform.iOS:
-        return '';
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        return localizations.dialogLabel;
-        break;
+  String _getRouteLabel() {
+    if (Theme.of(context, shadowThemeOnly: true) == null) {
+      return '';
+    } else {
+      final platform = Theme.of(context).platform;
+      switch (platform) {
+        case TargetPlatform.iOS:
+          return '';
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+          assert(debugCheckHasMaterialLocalizations(context));
+          return MaterialLocalizations.of(context).dialogLabel;
+          break;
+      }
+      return null;
     }
-    return null;
   }
 
   @override
@@ -64,9 +69,6 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    assert(debugCheckHasMaterialLocalizations(context));
-    final localizations = MaterialLocalizations.of(context);
-    final routeLabel = _getRouteLabel(localizations);
 
     return AnimatedBuilder(
       animation: widget.route._animationController,
@@ -76,7 +78,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
         return Semantics(
           scopesRoute: true,
           namesRoute: true,
-          label: routeLabel,
+          label: _getRouteLabel(),
           explicitChildNodes: true,
           child: ModalBottomSheet(
             expanded: widget.route.expanded,

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../modal_bottom_sheet.dart';
@@ -33,21 +34,19 @@ class _ModalBottomSheet<T> extends StatefulWidget {
 
 class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   String _getRouteLabel() {
-    if (Theme.of(context, shadowThemeOnly: true) == null) {
-      return '';
-    } else {
-      final platform = Theme.of(context).platform;
-      switch (platform) {
-        case TargetPlatform.iOS:
-          return '';
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-          assert(debugCheckHasMaterialLocalizations(context));
+    final platform = Theme.of(context)?.platform ?? defaultTargetPlatform;
+    switch (platform) {
+      case TargetPlatform.iOS:
+        return '';
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        if (Localizations.of(context, MaterialLocalizations) != null) {
           return MaterialLocalizations.of(context).dialogLabel;
-          break;
-      }
-      return null;
+        } else {
+          return DefaultMaterialLocalizations().dialogLabel;
+        }
     }
+    return null;
   }
 
   @override

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -4,10 +4,15 @@
 
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/cupertino.dart' show CupertinoTheme;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart'
+    show
+        Colors,
+        Theme,
+        MaterialLocalizations,
+        debugCheckHasMaterialLocalizations;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
@@ -78,7 +83,13 @@ Future<T> showCupertinoModalBottomSheet<T>({
   assert(useRootNavigator != null);
   assert(enableDrag != null);
   assert(debugCheckHasMediaQuery(context));
-  assert(debugCheckHasMaterialLocalizations(context));
+  final isCupertinoApp = Theme.of(context, shadowThemeOnly: true) == null;
+  String barrierLabel = '';
+  if (!isCupertinoApp) {
+    assert(debugCheckHasMaterialLocalizations(context));
+    barrierLabel = MaterialLocalizations.of(context).modalBarrierDismissLabel;
+  }
+
   final result = await Navigator.of(context, rootNavigator: useRootNavigator)
       .push(CupertinoModalBottomSheetRoute<T>(
     builder: builder,
@@ -88,7 +99,7 @@ Future<T> showCupertinoModalBottomSheet<T>({
     ),
     secondAnimationController: secondAnimation,
     expanded: expand,
-    barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    barrierLabel: barrierLabel,
     elevation: elevation,
     bounce: bounce,
     shape: shape,
@@ -264,7 +275,13 @@ class CupertinoScaffold extends StatefulWidget {
     assert(useRootNavigator != null);
     assert(enableDrag != null);
     assert(debugCheckHasMediaQuery(context));
-    assert(debugCheckHasMaterialLocalizations(context));
+    assert(debugCheckHasMediaQuery(context));
+    final isCupertinoApp = Theme.of(context, shadowThemeOnly: true) == null;
+    String barrierLabel = '';
+    if (!isCupertinoApp) {
+      assert(debugCheckHasMaterialLocalizations(context));
+      barrierLabel = MaterialLocalizations.of(context).modalBarrierDismissLabel;
+    }
     final result = await Navigator.of(context, rootNavigator: useRootNavigator)
         .push(CupertinoModalBottomSheetRoute<T>(
       builder: builder,
@@ -274,7 +291,7 @@ class CupertinoScaffold extends StatefulWidget {
         backgroundColor: backgroundColor,
       ),
       expanded: expand,
-      barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+      barrierLabel: barrierLabel,
       bounce: bounce,
       isDismissible: isDismissible ?? expand == false ? true : false,
       modalBarrierColor: barrierColor ?? Colors.black12,

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -83,12 +83,12 @@ Future<T> showCupertinoModalBottomSheet<T>({
   assert(useRootNavigator != null);
   assert(enableDrag != null);
   assert(debugCheckHasMediaQuery(context));
-  final isCupertinoApp = Theme.of(context, shadowThemeOnly: true) == null;
-  String barrierLabel = '';
-  if (!isCupertinoApp) {
-    assert(debugCheckHasMaterialLocalizations(context));
-    barrierLabel = MaterialLocalizations.of(context).modalBarrierDismissLabel;
-  }
+  final hasMaterialLocalizations =
+      Localizations.of<MaterialLocalizations>(context, MaterialLocalizations) !=
+          null;
+  final barrierLabel = hasMaterialLocalizations
+      ? MaterialLocalizations.of(context).modalBarrierDismissLabel
+      : '';
 
   final result = await Navigator.of(context, rootNavigator: useRootNavigator)
       .push(CupertinoModalBottomSheetRoute<T>(

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -275,7 +275,6 @@ class CupertinoScaffold extends StatefulWidget {
     assert(useRootNavigator != null);
     assert(enableDrag != null);
     assert(debugCheckHasMediaQuery(context));
-    assert(debugCheckHasMediaQuery(context));
     final isCupertinoApp = Theme.of(context, shadowThemeOnly: true) == null;
     String barrierLabel = '';
     if (!isCupertinoApp) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modal_bottom_sheet
 description: 'Create awesome and powerful modal bottom sheets. Material, Cupertino or create your own'
-version: 0.1.4
+version: 0.1.5
 homepage: 'https://github.com/jamesblasco/modal_bottom_sheet'
 
 environment:


### PR DESCRIPTION
This fixes #6 .

Also I fixed some issues when using CupertinoBottomSheet and BottomSheetRoute without having Material widget in the widget tree. The CupertinoBottomSheet has an assertion to MaterialLocalizations which not needed at every time. Therefore I've added a check if the root is a MaterialApp, if it is, the package works as before this PR. If not I assume that the root widget is a CupertinoApp and use default values, because, if I'm not wrong, the CupertinoLocalizations does not contains the needed values.

So this PR makes it possible to use the CupertinoBottomSheet in an CupertinoApp. 