### PR TITLE
Expose Curve for animating the route and the modal

### DIFF
--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -38,6 +38,7 @@ class ModalBottomSheet extends StatefulWidget {
   const ModalBottomSheet({
     Key key,
     this.animationController,
+    this.animationCurve,
     this.enableDrag = true,
     this.containerBuilder,
     this.bounce = true,
@@ -57,6 +58,11 @@ class ModalBottomSheet extends StatefulWidget {
   /// The BottomSheet widget will manipulate the position of this animation, it
   /// is not just a passive observer.
   final AnimationController animationController;
+
+  /// The curve used by the animation showing and dismissing the bottom sheet.
+  /// 
+  /// If no curve is provided it falls back to `Curves.easeOutSine`.
+  final Curve animationCurve;
 
   /// Allows the bottom sheet to  go beyond the top bound of the content,
   /// but then bounce the content back to the edge of
@@ -276,7 +282,7 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
   Widget build(BuildContext context) {
     final bounceAnimation = CurvedAnimation(
       parent: _bounceDragController,
-      curve: Curves.easeOutSine,
+      curve: widget.animationCurve ?? Curves.easeOutSine,
     );
 
     var child = widget.builder(context, _scrollController);

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -17,6 +17,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
     this.scrollController,
     this.expanded = false,
     this.enableDrag = true,
+    this.animationCurve,
   })  : assert(expanded != null),
         assert(enableDrag != null),
         super(key: key);
@@ -26,6 +27,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final bool bounce;
   final bool enableDrag;
   final AnimationController secondAnimationController;
+  final Curve animationCurve;
   final ScrollController scrollController;
 
   @override
@@ -97,6 +99,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
             builder: widget.route.builder,
             enableDrag: widget.enableDrag,
             bounce: widget.bounce,
+            animationCurve: widget.animationCurve,
           ),
         );
       },
@@ -116,6 +119,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.enableDrag = true,
     @required this.expanded,
     this.bounce = false,
+    this.animationCurve,
     RouteSettings settings,
   })  : assert(expanded != null),
         assert(isDismissible != null),
@@ -132,6 +136,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final ScrollController scrollController;
 
   final AnimationController secondAnimationController;
+  final Curve animationCurve;
 
   @override
   Duration get transitionDuration => _bottomSheetDuration;
@@ -172,6 +177,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
         scrollController: scrollController,
         bounce: bounce,
         enableDrag: enableDrag,
+        animationCurve: animationCurve,
       ),
     );
     return bottomSheet;
@@ -195,22 +201,24 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
 }
 
 /// Shows a modal material design bottom sheet.
-Future<T> showCustomModalBottomSheet<T>(
-    {@required BuildContext context,
-    @required ScrollWidgetBuilder builder,
-    @required WidgetWithChildBuilder containerWidget,
-    Color backgroundColor,
-    double elevation,
-    ShapeBorder shape,
-    Clip clipBehavior,
-    Color barrierColor,
-    bool bounce = false,
-    bool expand = false,
-    AnimationController secondAnimation,
-    bool useRootNavigator = false,
-    bool isDismissible = true,
-    bool enableDrag = true,
-    ScrollController scrollController}) async {
+Future<T> showCustomModalBottomSheet<T>({
+  @required BuildContext context,
+  @required ScrollWidgetBuilder builder,
+  @required WidgetWithChildBuilder containerWidget,
+  Color backgroundColor,
+  double elevation,
+  ShapeBorder shape,
+  Clip clipBehavior,
+  Color barrierColor,
+  bool bounce = false,
+  bool expand = false,
+  AnimationController secondAnimation,
+  Curve animationCurve,
+  bool useRootNavigator = false,
+  bool isDismissible = true,
+  bool enableDrag = true,
+  ScrollController scrollController,
+}) async {
   assert(context != null);
   assert(builder != null);
   assert(containerWidget != null);
@@ -231,6 +239,7 @@ Future<T> showCustomModalBottomSheet<T>(
     isDismissible: isDismissible,
     modalBarrierColor: barrierColor,
     enableDrag: enableDrag,
+    animationCurve: animationCurve,
   ));
   return result;
 }

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -66,6 +66,7 @@ Future<T> showBarModalBottomSheet<T>({
   bool bounce = true,
   bool expand = false,
   AnimationController secondAnimation,
+  Curve animationCurve,
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
@@ -91,6 +92,7 @@ Future<T> showBarModalBottomSheet<T>({
     isDismissible: isDismissible,
     modalBarrierColor: barrierColor,
     enableDrag: enableDrag,
+    animationCurve: animationCurve,
   ));
   return result;
 }

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -72,6 +72,8 @@ Future<T> showCupertinoModalBottomSheet<T>({
   Color barrierColor,
   bool expand = false,
   AnimationController secondAnimation,
+  Curve routeAnimationCurve,
+  Curve modalAnimationCurve,
   bool useRootNavigator = false,
   bool bounce = true,
   bool isDismissible,
@@ -107,11 +109,15 @@ Future<T> showCupertinoModalBottomSheet<T>({
     isDismissible: isDismissible ?? expand == false ? true : false,
     modalBarrierColor: barrierColor ?? Colors.black12,
     enableDrag: enableDrag,
+    routeAnimationCurve: routeAnimationCurve,
+    modalAnimationCurve: modalAnimationCurve,
   ));
   return result;
 }
 
 class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
+  final Curve modalAnimationCurve;
+
   CupertinoModalBottomSheetRoute({
     ScrollWidgetBuilder builder,
     WidgetWithChildBuilder containerBuilder,
@@ -120,12 +126,14 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
     ShapeBorder shape,
     Clip clipBehavior,
     AnimationController secondAnimationController,
+    Curve routeAnimationCurve,
     Color modalBarrierColor,
     bool bounce = true,
     bool isDismissible = true,
     bool enableDrag = true,
     @required bool expanded,
     RouteSettings settings,
+    this.modalAnimationCurve,
   })  : assert(expanded != null),
         assert(isDismissible != null),
         assert(enableDrag != null),
@@ -140,6 +148,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
           enableDrag: enableDrag,
           expanded: expanded,
           settings: settings,
+          animationCurve: routeAnimationCurve,
         );
 
   @override
@@ -172,18 +181,25 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
   Widget getPreviousRouteTransition(BuildContext context,
       Animation<double> secondaryAnimation, Widget child) {
     return _CupertinoModalTransition(
-        secondaryAnimation: secondaryAnimation, body: child);
+      secondaryAnimation: secondaryAnimation,
+      body: child,
+      animationCurve: modalAnimationCurve,
+    );
   }
 }
 
 class _CupertinoModalTransition extends StatelessWidget {
   final Animation<double> secondaryAnimation;
+  final Curve animationCurve;
 
   final Widget body;
 
-  const _CupertinoModalTransition(
-      {Key key, @required this.secondaryAnimation, @required this.body})
-      : super(key: key);
+  const _CupertinoModalTransition({
+    Key key,
+    @required this.secondaryAnimation,
+    @required this.body,
+    this.animationCurve,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -196,7 +212,7 @@ class _CupertinoModalTransition extends StatelessWidget {
 
     final curvedAnimation = CurvedAnimation(
       parent: secondaryAnimation,
-      curve: Curves.easeOut,
+      curve: animationCurve ?? Curves.easeOut,
     );
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
@@ -261,6 +277,8 @@ class CupertinoScaffold extends StatefulWidget {
   static Future<T> showCupertinoModalBottomSheet<T>({
     @required BuildContext context,
     @required ScrollWidgetBuilder builder,
+    Curve routeAnimationCurve,
+    Curve modalAnimationCurve,
     Color backgroundColor,
     Color barrierColor,
     bool expand = false,
@@ -295,6 +313,8 @@ class CupertinoScaffold extends StatefulWidget {
       isDismissible: isDismissible ?? expand == false ? true : false,
       modalBarrierColor: barrierColor ?? Colors.black12,
       enableDrag: enableDrag,
+      routeAnimationCurve: routeAnimationCurve,
+      modalAnimationCurve: modalAnimationCurve,
     ));
     return result;
   }

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -72,8 +72,8 @@ Future<T> showCupertinoModalBottomSheet<T>({
   Color barrierColor,
   bool expand = false,
   AnimationController secondAnimation,
-  Curve routeAnimationCurve,
-  Curve modalAnimationCurve,
+  Curve animationCurve,
+  Curve previousRouteAnimationCurve,
   bool useRootNavigator = false,
   bool bounce = true,
   bool isDismissible,
@@ -109,14 +109,14 @@ Future<T> showCupertinoModalBottomSheet<T>({
     isDismissible: isDismissible ?? expand == false ? true : false,
     modalBarrierColor: barrierColor ?? Colors.black12,
     enableDrag: enableDrag,
-    routeAnimationCurve: routeAnimationCurve,
-    modalAnimationCurve: modalAnimationCurve,
+    animationCurve: animationCurve,
+    previousRouteAnimationCurve: previousRouteAnimationCurve,
   ));
   return result;
 }
 
 class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
-  final Curve modalAnimationCurve;
+  final Curve previousRouteAnimationCurve;
 
   CupertinoModalBottomSheetRoute({
     ScrollWidgetBuilder builder,
@@ -126,14 +126,14 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
     ShapeBorder shape,
     Clip clipBehavior,
     AnimationController secondAnimationController,
-    Curve routeAnimationCurve,
+    Curve animationCurve,
     Color modalBarrierColor,
     bool bounce = true,
     bool isDismissible = true,
     bool enableDrag = true,
     @required bool expanded,
     RouteSettings settings,
-    this.modalAnimationCurve,
+    this.previousRouteAnimationCurve,
   })  : assert(expanded != null),
         assert(isDismissible != null),
         assert(enableDrag != null),
@@ -148,7 +148,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
           enableDrag: enableDrag,
           expanded: expanded,
           settings: settings,
-          animationCurve: routeAnimationCurve,
+          animationCurve: animationCurve,
         );
 
   @override
@@ -183,7 +183,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
     return _CupertinoModalTransition(
       secondaryAnimation: secondaryAnimation,
       body: child,
-      animationCurve: modalAnimationCurve,
+      animationCurve: previousRouteAnimationCurve,
     );
   }
 }
@@ -277,8 +277,8 @@ class CupertinoScaffold extends StatefulWidget {
   static Future<T> showCupertinoModalBottomSheet<T>({
     @required BuildContext context,
     @required ScrollWidgetBuilder builder,
-    Curve routeAnimationCurve,
-    Curve modalAnimationCurve,
+    Curve animationCurve,
+    Curve previousRouteAnimationCurve,
     Color backgroundColor,
     Color barrierColor,
     bool expand = false,
@@ -313,8 +313,8 @@ class CupertinoScaffold extends StatefulWidget {
       isDismissible: isDismissible ?? expand == false ? true : false,
       modalBarrierColor: barrierColor ?? Colors.black12,
       enableDrag: enableDrag,
-      routeAnimationCurve: routeAnimationCurve,
-      modalAnimationCurve: modalAnimationCurve,
+      animationCurve: animationCurve,
+      previousRouteAnimationCurve: previousRouteAnimationCurve,
     ));
     return result;
   }

--- a/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -14,6 +14,7 @@ Future<T> showMaterialModalBottomSheet<T>({
   bool bounce = false,
   bool expand = false,
   AnimationController secondAnimation,
+  Curve animationCurve,
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
@@ -44,6 +45,7 @@ Future<T> showMaterialModalBottomSheet<T>({
     isDismissible: isDismissible,
     modalBarrierColor: barrierColor,
     enableDrag: enableDrag,
+    animationCurve: animationCurve,
   ));
   return result;
 }


### PR DESCRIPTION
With this PR the Curves used by the animation of the ModalBottomSheet and the _CupertinoModalTransition. 

This resolves feature request 2 from #13 .

It contains some formatting, but I tried to avoid too much formatting. However, there are some places where formatting might improve readability, but this should be additional PR.