### PR TITLE
Use PrimaryScrollController

### DIFF
--- a/example/lib/examples/cupertino_share.dart
+++ b/example/lib/examples/cupertino_share.dart
@@ -53,8 +53,8 @@ class CupertinoSharePage extends StatelessWidget {
                 expand: true,
                 context: context,
                 backgroundColor: Colors.transparent,
-                builder: (context, scrollController) =>
-                    PhotoShareBottomSheet(scrollController: scrollController),
+                builder: (context) =>
+                    PhotoShareBottomSheet(),
               );
             },
           ),
@@ -73,9 +73,9 @@ class CupertinoSharePage extends StatelessWidget {
 }
 
 class PhotoShareBottomSheet extends StatelessWidget {
-  final ScrollController scrollController;
 
-  const PhotoShareBottomSheet({Key key, this.scrollController})
+
+  const PhotoShareBottomSheet({Key key})
       : super(key: key);
 
   @override
@@ -92,7 +92,7 @@ class PhotoShareBottomSheet extends StatelessWidget {
               appBar: appBar(context),
               body: CustomScrollView(
                 physics: ClampingScrollPhysics(),
-                controller: scrollController,
+                primary: true,
                 slivers: <Widget>[
                   SliverSafeArea(
                     bottom: false,

--- a/example/lib/examples/cupertino_share.dart
+++ b/example/lib/examples/cupertino_share.dart
@@ -92,7 +92,7 @@ class PhotoShareBottomSheet extends StatelessWidget {
               appBar: appBar(context),
               body: CustomScrollView(
                 physics: ClampingScrollPhysics(),
-                primary: true,
+                  controller: ModalScrollController.of(context),
                 slivers: <Widget>[
                   SliverSafeArea(
                     bottom: false,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,11 +50,9 @@ class MyApp extends StatelessWidget {
                                     expand: true,
                                     context: context,
                                     backgroundColor: Colors.transparent,
-                                    builder: (context, scrollController) =>
-                                        Stack(
+                                    builder: (context) => Stack(
                                       children: <Widget>[
-                                        ModalWithScroll(
-                                            scrollController: scrollController),
+                                        ModalWithScroll(),
                                         Positioned(
                                           height: 40,
                                           left: 40,
@@ -130,8 +128,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: false,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalFit(scrollController: scrollController),
+                              builder: (context) => ModalFit(),
                             )),
                     ListTile(
                         title: Text('Bar Modal'),
@@ -139,9 +136,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalInsideModal(
-                                      scrollController: scrollController),
+                              builder: (context) => ModalInsideModal(),
                             )),
                     ListTile(
                         title: Text('Avatar Modal'),
@@ -149,16 +144,13 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalInsideModal(
-                                      scrollController: scrollController),
+                              builder: (context) => ModalInsideModal(),
                             )),
                     ListTile(
                         title: Text('Float Modal'),
                         onTap: () => showFloatingModalBottomSheet(
                               context: context,
-                              builder: (context, scrollController) =>
-                                  ModalFit(scrollController: scrollController),
+                              builder: (context) => ModalFit(),
                             )),
                     ListTile(
                         title: Text('Cupertino Modal fit'),
@@ -166,8 +158,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: false,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalFit(scrollController: scrollController),
+                              builder: (context) => ModalFit(),
                             )),
                     section('COMPLEX CASES'),
                     ListTile(
@@ -176,8 +167,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalFit(scrollController: scrollController),
+                              builder: (context) => ModalFit(),
                             )),
                     ListTile(
                         title: Text('Reverse list'),
@@ -185,10 +175,8 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalInsideModal(
-                                      scrollController: scrollController,
-                                      reverse: true),
+                              builder: (context) =>
+                                  ModalInsideModal(reverse: true),
                             )),
                     ListTile(
                         title: Text('Cupertino Modal inside modal'),
@@ -196,9 +184,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalInsideModal(
-                                      scrollController: scrollController),
+                              builder: (context) => ModalInsideModal(),
                             )),
                     ListTile(
                         title: Text('Cupertino Modal with inside navigation'),
@@ -206,9 +192,7 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalWithNavigator(
-                                      scrollController: scrollController),
+                              builder: (context) => ModalWithNavigator(),
                             )),
                     ListTile(
                         title:
@@ -217,9 +201,8 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ComplexModal(
-                                      scrollController: scrollController),
+                              builder: (context) =>
+                                  ComplexModal(),
                             )),
                     ListTile(
                         title: Text('Modal with WillPopScope'),
@@ -227,18 +210,16 @@ class _MyHomePageState extends State<MyHomePage> {
                               expand: true,
                               context: context,
                               backgroundColor: Colors.transparent,
-                              builder: (context, scrollController) =>
-                                  ModalWillScope(
-                                      scrollController: scrollController),
+                              builder: (context) =>
+                                  ModalWillScope(),
                             )),
                     ListTile(
                         title: Text('Modal with Nested Scroll'),
                         onTap: () => showCupertinoModalBottomSheet(
                               expand: true,
                               context: context,
-                              builder: (context, scrollController) =>
-                                  NestedScrollModal(
-                                      scrollController: scrollController),
+                              builder: (context) =>
+                                  NestedScrollModal(),
                             )),
                     SizedBox(
                       height: 60,

--- a/example/lib/modals/circular_modal.dart
+++ b/example/lib/modals/circular_modal.dart
@@ -69,7 +69,7 @@ class AvatarBottomSheet extends StatelessWidget {
 
 Future<T> showAvatarModalBottomSheet<T>({
   @required BuildContext context,
-  @required ScrollWidgetBuilder builder,
+  @required WidgetBuilder builder,
   Color backgroundColor,
   double elevation,
   ShapeBorder shape,

--- a/example/lib/modals/floating_modal.dart
+++ b/example/lib/modals/floating_modal.dart
@@ -27,7 +27,7 @@ class FloatingModal extends StatelessWidget {
 
 Future<T> showFloatingModalBottomSheet<T>({
   @required BuildContext context,
-  @required ScrollWidgetBuilder builder,
+  @required WidgetBuilder builder,
   Color backgroundColor,
 }) async {
   final result = await showCustomModalBottomSheet(

--- a/example/lib/modals/modal_complex_all.dart
+++ b/example/lib/modals/modal_complex_all.dart
@@ -2,12 +2,13 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class ComplexModal extends StatelessWidget {
-  final ScrollController scrollController;
 
-  const ComplexModal({Key key, this.scrollController}) : super(key: key);
+
+  const ComplexModal({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final scrollController = PrimaryScrollController.of(context);
     return Material(
       child: WillPopScope(
         onWillPop: () async {
@@ -46,6 +47,7 @@ class ComplexModal extends StatelessWidget {
                   bottom: false,
                   child: ListView(
                     shrinkWrap: true,
+
                     controller: scrollController,
                     children: ListTile.divideTiles(
                       context: context,

--- a/example/lib/modals/modal_complex_all.dart
+++ b/example/lib/modals/modal_complex_all.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 class ComplexModal extends StatelessWidget {
-
-
   const ComplexModal({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final scrollController = PrimaryScrollController.of(context);
     return Material(
       child: WillPopScope(
         onWillPop: () async {
@@ -47,8 +45,7 @@ class ComplexModal extends StatelessWidget {
                   bottom: false,
                   child: ListView(
                     shrinkWrap: true,
-
-                    controller: scrollController,
+                    controller: ModalScrollController.of(context),
                     children: ListTile.divideTiles(
                       context: context,
                       tiles: List.generate(

--- a/example/lib/modals/modal_fit.dart
+++ b/example/lib/modals/modal_fit.dart
@@ -2,9 +2,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class ModalFit extends StatelessWidget {
-  final ScrollController scrollController;
 
-  const ModalFit({Key key, this.scrollController}) : super(key: key);
+
+  const ModalFit({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/modals/modal_inside_modal.dart
+++ b/example/lib/modals/modal_inside_modal.dart
@@ -3,14 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 class ModalInsideModal extends StatelessWidget {
-  final ScrollController scrollController;
   final bool reverse;
 
-  const ModalInsideModal({Key key, this.scrollController, this.reverse = false})
-      : super(key: key);
+  const ModalInsideModal({Key key, this.reverse = false}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final scrollController = PrimaryScrollController.of(context);
     return Material(
         child: CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
@@ -20,7 +19,7 @@ class ModalInsideModal extends StatelessWidget {
         child: ListView(
           reverse: reverse,
           shrinkWrap: true,
-          controller: scrollController,
+            controller: scrollController,
           physics: ClampingScrollPhysics(),
           children: ListTile.divideTiles(
               context: context,
@@ -33,10 +32,8 @@ class ModalInsideModal extends StatelessWidget {
                           isDismissible: false,
                           context: context,
                           backgroundColor: Colors.transparent,
-                          builder: (context, scrollController) =>
-                              ModalInsideModal(
-                                  scrollController: scrollController,
-                                  reverse: reverse),
+                          builder: (context) =>
+                              ModalInsideModal(reverse: reverse),
                         )),
               )).toList(),
         ),

--- a/example/lib/modals/modal_inside_modal.dart
+++ b/example/lib/modals/modal_inside_modal.dart
@@ -9,7 +9,6 @@ class ModalInsideModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scrollController = PrimaryScrollController.of(context);
     return Material(
         child: CupertinoPageScaffold(
       navigationBar: CupertinoNavigationBar(
@@ -19,7 +18,7 @@ class ModalInsideModal extends StatelessWidget {
         child: ListView(
           reverse: reverse,
           shrinkWrap: true,
-            controller: scrollController,
+          controller: ModalScrollController.of(context),
           physics: ClampingScrollPhysics(),
           children: ListTile.divideTiles(
               context: context,

--- a/example/lib/modals/modal_will_scope.dart
+++ b/example/lib/modals/modal_will_scope.dart
@@ -2,9 +2,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class ModalWillScope extends StatelessWidget {
-  final ScrollController scrollController;
 
-  const ModalWillScope({Key key, this.scrollController}) : super(key: key);
+
+  const ModalWillScope({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/modals/modal_with_navigator.dart
+++ b/example/lib/modals/modal_with_navigator.dart
@@ -2,12 +2,13 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class ModalWithNavigator extends StatelessWidget {
-  final ScrollController scrollController;
 
-  const ModalWithNavigator({Key key, this.scrollController}) : super(key: key);
+
+  const ModalWithNavigator({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final scrollController = PrimaryScrollController.of(context);
     return Material(
         child: Navigator(
       onGenerateRoute: (_) => MaterialPageRoute(

--- a/example/lib/modals/modal_with_navigator.dart
+++ b/example/lib/modals/modal_with_navigator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 class ModalWithNavigator extends StatelessWidget {
 
@@ -8,7 +9,6 @@ class ModalWithNavigator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scrollController = PrimaryScrollController.of(context);
     return Material(
         child: Navigator(
       onGenerateRoute: (_) => MaterialPageRoute(
@@ -20,7 +20,7 @@ class ModalWithNavigator extends StatelessWidget {
               bottom: false,
               child: ListView(
                 shrinkWrap: true,
-                controller: scrollController,
+                controller: ModalScrollController.of(context),
                 children: ListTile.divideTiles(
                   context: context,
                   tiles: List.generate(

--- a/example/lib/modals/modal_with_nested_scroll.dart
+++ b/example/lib/modals/modal_with_nested_scroll.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 class NestedScrollModal extends StatelessWidget {
   const NestedScrollModal({Key key}) : super(key: key);
@@ -7,7 +8,6 @@ class NestedScrollModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scrollController = PrimaryScrollController.of(context);
     return NestedScrollView(
       controller: ScrollController(),
       physics: ScrollPhysics(parent: PageScrollPhysics()),
@@ -23,7 +23,7 @@ class NestedScrollModal extends StatelessWidget {
         ];
       },
       body: ListView.builder(
-        controller: scrollController,
+        controller: ModalScrollController.of(context),
         itemBuilder: (context, index) {
           return Container(
             height: 100,

--- a/example/lib/modals/modal_with_nested_scroll.dart
+++ b/example/lib/modals/modal_with_nested_scroll.dart
@@ -2,12 +2,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class NestedScrollModal extends StatelessWidget {
-  final ScrollController scrollController;
+  const NestedScrollModal({Key key}) : super(key: key);
 
-  const NestedScrollModal({Key key, this.scrollController}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final scrollController = PrimaryScrollController.of(context);
     return NestedScrollView(
       controller: ScrollController(),
       physics: ScrollPhysics(parent: PageScrollPhysics()),

--- a/example/lib/modals/modal_with_scroll.dart
+++ b/example/lib/modals/modal_with_scroll.dart
@@ -2,12 +2,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class ModalWithScroll extends StatelessWidget {
-  final ScrollController scrollController;
-
-  const ModalWithScroll({Key key, this.scrollController}) : super(key: key);
+  const ModalWithScroll({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final scrollController = PrimaryScrollController.of(context);
     return Material(
       child: CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(

--- a/example/lib/modals/modal_with_scroll.dart
+++ b/example/lib/modals/modal_with_scroll.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 class ModalWithScroll extends StatelessWidget {
   const ModalWithScroll({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final scrollController = PrimaryScrollController.of(context);
+  
     return Material(
       child: CupertinoPageScaffold(
         navigationBar: CupertinoNavigationBar(
@@ -15,7 +16,7 @@ class ModalWithScroll extends StatelessWidget {
           bottom: false,
           child: ListView(
             shrinkWrap: true,
-            controller: scrollController,
+            controller: ModalScrollController.of(context),
             children: ListTile.divideTiles(
               context: context,
               tiles: List.generate(

--- a/lib/modal_bottom_sheet.dart
+++ b/lib/modal_bottom_sheet.dart
@@ -4,3 +4,4 @@ export 'src/material_with_modal_page_route.dart';
 export 'src/bottom_sheets/cupertino_bottom_sheet.dart';
 export 'src/bottom_sheets/material_bottom_sheet.dart';
 export 'src/bottom_sheets/bar_bottom_sheet.dart';
+export 'src/utils/modal_scroll_controller.dart';

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -10,7 +10,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
-import 'package:modal_bottom_sheet/src/utils/primary_scroll_status_bar.dart';
+import 'package:modal_bottom_sheet/src/utils/scroll_to_top_status_bar.dart';
 
 import 'package:modal_bottom_sheet/src/utils/bottom_sheet_suspended_curve.dart';
 
@@ -282,7 +282,7 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
         return;
       }
 
-// Otherwise the calculate the velocity with a VelocityTracker
+      // Otherwise the calculate the velocity with a VelocityTracker
       if (_velocityTracker == null) {
         _velocityTracker = VelocityTracker();
         _startTime = DateTime.now();
@@ -385,7 +385,10 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
       child: RepaintBoundary(child: child),
     );
 
-    return PrimaryScrollStatusBarHandler(child: child);
+    return ScrollToTopStatusBarHandler(
+      child: child,
+      scrollController: _scrollController,
+    );
   }
 }
 

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:modal_bottom_sheet/src/utils/modal_scroll_controller.dart';
 
 import '../modal_bottom_sheet.dart';
 
@@ -74,10 +75,10 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-
-    return PrimaryScrollController(
-      controller: PrimaryScrollController.of(context) ??
-          (_scrollController ??= ScrollController()),
+    final scrollController = PrimaryScrollController.of(context) ??
+          (_scrollController ??= ScrollController());
+    return ModalScrollController(
+      controller: scrollController,
       child: Builder(
         builder: (context) => AnimatedBuilder(
           animation: widget.route._animationController,
@@ -107,7 +108,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 child: child,
                 enableDrag: widget.enableDrag,
                 bounce: widget.bounce,
-                scrollController: PrimaryScrollController.of(context),
+                scrollController: scrollController,
                 animationCurve: widget.animationCurve,
               ),
             );

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -14,7 +14,6 @@ class _ModalBottomSheet<T> extends StatefulWidget {
     this.route,
     this.secondAnimationController,
     this.bounce = false,
-    this.scrollController,
     this.expanded = false,
     this.enableDrag = true,
     this.animationCurve,
@@ -28,7 +27,6 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final bool enableDrag;
   final AnimationController secondAnimationController;
   final Curve animationCurve;
-  final ScrollController scrollController;
 
   @override
   _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
@@ -54,6 +52,8 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
     return null;
   }
 
+  ScrollController _scrollController;
+
   @override
   void initState() {
     widget.route.animation.addListener(updateController);
@@ -63,6 +63,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   @override
   void dispose() {
     widget.route.animation.removeListener(updateController);
+    _scrollController?.dispose();
     super.dispose();
   }
 
@@ -74,39 +75,46 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
 
-    return AnimatedBuilder(
-      animation: widget.route._animationController,
-      builder: (BuildContext context, Widget child) {
-        // Disable the initial animation when accessible navigation is on so
-        // that the semantics are added to the tree at the correct time.
-        return Semantics(
-          scopesRoute: true,
-          namesRoute: true,
-          label: _getRouteLabel(),
-          explicitChildNodes: true,
-          child: ModalBottomSheet(
-            expanded: widget.route.expanded,
-            containerBuilder: widget.route.containerBuilder,
-            animationController: widget.route._animationController,
-            shouldClose: widget.route._hasScopedWillPopCallback
-                ? () async {
-                    final willPop = await widget.route.willPop();
-                    return willPop != RoutePopDisposition.doNotPop;
+    return PrimaryScrollController(
+      controller: PrimaryScrollController.of(context) ??
+          (_scrollController ??= ScrollController()),
+      child: Builder(
+        builder: (context) => AnimatedBuilder(
+          animation: widget.route._animationController,
+          builder: (BuildContext context, Widget child) {
+            // Disable the initial animation when accessible navigation is on so
+            // that the semantics are added to the tree at the correct time.
+            return Semantics(
+              scopesRoute: true,
+              namesRoute: true,
+              label: _getRouteLabel(),
+              explicitChildNodes: true,
+              child: ModalBottomSheet(
+                expanded: widget.route.expanded,
+                containerBuilder: widget.route.containerBuilder,
+                animationController: widget.route._animationController,
+                shouldClose: widget.route._hasScopedWillPopCallback
+                    ? () async {
+                        final willPop = await widget.route.willPop();
+                        return willPop != RoutePopDisposition.doNotPop;
+                      }
+                    : null,
+                onClosing: () {
+                  if (widget.route.isCurrent) {
+                    Navigator.of(context).pop();
                   }
-                : null,
-            onClosing: () {
-              if (widget.route.isCurrent) {
-                Navigator.of(context).pop();
-              }
-            },
-            builder: widget.route.builder,
-            enableDrag: widget.enableDrag,
-            bounce: widget.bounce,
-            scrollController: widget.scrollController,
-            animationCurve: widget.animationCurve,
-          ),
-        );
-      },
+                },
+                child: child,
+                enableDrag: widget.enableDrag,
+                bounce: widget.bounce,
+                scrollController: PrimaryScrollController.of(context),
+                animationCurve: widget.animationCurve,
+              ),
+            );
+          },
+          child: widget.route.builder(context),
+        ),
+      ),
     );
   }
 }
@@ -132,7 +140,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
         super(settings: settings);
 
   final WidgetWithChildBuilder containerBuilder;
-  final ScrollWidgetBuilder builder;
+  final WidgetBuilder builder;
   final bool expanded;
   final bool bounce;
   final Color modalBarrierColor;
@@ -183,7 +191,6 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
         route: this,
         secondAnimationController: secondAnimationController,
         expanded: expanded,
-        scrollController: scrollController,
         bounce: bounce,
         enableDrag: enableDrag,
         animationCurve: animationCurve,
@@ -212,7 +219,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
 /// Shows a modal material design bottom sheet.
 Future<T> showCustomModalBottomSheet<T>({
   @required BuildContext context,
-  @required ScrollWidgetBuilder builder,
+  @required WidgetBuilder builder,
   @required WidgetWithChildBuilder containerWidget,
   Color backgroundColor,
   double elevation,
@@ -226,7 +233,6 @@ Future<T> showCustomModalBottomSheet<T>({
   bool useRootNavigator = false,
   bool isDismissible = true,
   bool enableDrag = true,
-  ScrollController scrollController,
   Duration duration,
 }) async {
   assert(context != null);

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -71,7 +71,7 @@ class BarBottomSheet extends StatelessWidget {
 
 Future<T> showBarModalBottomSheet<T>({
   @required BuildContext context,
-  @required ScrollWidgetBuilder builder,
+  @required WidgetBuilder builder,
   Color backgroundColor,
   double elevation,
   ShapeBorder shape,

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -67,7 +67,7 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
 
 Future<T> showCupertinoModalBottomSheet<T>({
   @required BuildContext context,
-  @required ScrollWidgetBuilder builder,
+  @required WidgetBuilder builder,
   Color backgroundColor,
   double elevation,
   ShapeBorder shape,
@@ -137,7 +137,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
   final Color transitionBackgroundColor;
 
   CupertinoModalBottomSheetRoute({
-    ScrollWidgetBuilder builder,
+    WidgetBuilder builder,
     WidgetWithChildBuilder containerBuilder,
     String barrierLabel,
     double elevation,
@@ -317,7 +317,7 @@ class CupertinoScaffold extends StatefulWidget {
 
   static Future<T> showCupertinoModalBottomSheet<T>({
     @required BuildContext context,
-    @required ScrollWidgetBuilder builder,
+    @required WidgetBuilder builder,
     Curve animationCurve,
     Curve previousRouteAnimationCurve,
     Color backgroundColor,

--- a/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 /// Shows a modal material design bottom sheet.
 Future<T> showMaterialModalBottomSheet<T>({
   @required BuildContext context,
-  @required ScrollWidgetBuilder builder,
+  @required WidgetBuilder builder,
   Color backgroundColor,
   double elevation,
   ShapeBorder shape,

--- a/lib/src/utils/modal_scroll_controller.dart
+++ b/lib/src/utils/modal_scroll_controller.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Associates a [ScrollController] with a subtree.
+///
+/// This mechanism can be used to provide default behavior for scroll views in a
+/// subtree inside a modal bottom sheet.
+///
+/// We want to remove this and use [PrimaryScrollController].
+/// This issue should be solved first https://github.com/flutter/flutter/issues/64236
+///
+/// See [PrimaryScrollController]
+class ModalScrollController extends InheritedWidget {
+  /// Creates a widget that associates a [ScrollController] with a subtree.
+  ModalScrollController({
+    Key key,
+    @required this.controller,
+    @required Widget child,
+  })  : assert(controller != null),
+        super(
+          key: key,
+          child: PrimaryScrollController(
+            controller: controller,
+            child: child,
+          ),
+        );
+
+  /// The [ScrollController] associated with the subtree.
+  ///
+  /// See also:
+  ///
+  ///  * [ScrollView.controller], which discusses the purpose of specifying a
+  ///    scroll controller.
+  final ScrollController controller;
+
+  /// Returns the [ScrollController] most closely associated with the given
+  /// context.
+  ///
+  /// Returns null if there is no [ScrollController] associated with the given
+  /// context.
+  static ScrollController of(BuildContext context) {
+    final ModalScrollController result =
+        context.dependOnInheritedWidgetOfExactType<ModalScrollController>();
+    return result?.controller;
+  }
+
+  @override
+  bool updateShouldNotify(ModalScrollController oldWidget) =>
+      controller != oldWidget.controller;
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<ScrollController>(
+        'controller', controller,
+        ifNull: 'no controller', showName: false));
+  }
+}

--- a/lib/src/utils/primary_scroll_status_bar.dart
+++ b/lib/src/utils/primary_scroll_status_bar.dart
@@ -4,55 +4,47 @@ import 'package:flutter/widgets.dart';
 /// scroll to the top when tapped on the status bar
 ///
 class PrimaryScrollStatusBarHandler extends StatefulWidget {
-  final ScrollController scrollController;
   final Widget child;
 
-  const PrimaryScrollStatusBarHandler(
-      {Key key, this.child, this.scrollController})
-      : super(key: key);
+  const PrimaryScrollStatusBarHandler({Key key, this.child}) : super(key: key);
+
   @override
   _PrimaryScrollWidgetState createState() => _PrimaryScrollWidgetState();
 }
 
 class _PrimaryScrollWidgetState extends State<PrimaryScrollStatusBarHandler> {
-  ScrollController controller;
-
   @override
   void initState() {
-    controller = widget.scrollController ?? ScrollController();
     super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
-    return PrimaryScrollController(
-      controller: controller,
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          widget.child,
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            height: MediaQuery.of(context).padding.top,
-            child: Builder(
-              builder: (context) => GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () => _handleStatusBarTap(context),
-                // iOS accessibility automatically adds scroll-to-top to the clock in the status bar
-                excludeFromSemantics: true,
-              ),
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          height: MediaQuery.of(context).padding.top,
+          child: Builder(
+            builder: (context) => GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => _handleStatusBarTap(context),
+              // iOS accessibility automatically adds scroll-to-top to the clock in the status bar
+              excludeFromSemantics: true,
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
   void _handleStatusBarTap(BuildContext context) {
     final controller = PrimaryScrollController.of(context);
-    if (controller.hasClients) {
+    if (controller != null && controller.hasClients) {
       controller.animateTo(
         0.0,
         duration: const Duration(milliseconds: 300),

--- a/lib/src/utils/scroll_to_top_status_bar.dart
+++ b/lib/src/utils/scroll_to_top_status_bar.dart
@@ -1,18 +1,23 @@
 import 'package:flutter/widgets.dart';
 
-/// Creates a primary scroll controller that will
-/// scroll to the top when tapped on the status bar
+/// Widget that that will scroll to the top the ScrollController
+/// when tapped on the status bar
 ///
-class PrimaryScrollStatusBarHandler extends StatefulWidget {
+class ScrollToTopStatusBarHandler extends StatefulWidget {
   final Widget child;
+  final ScrollController scrollController;
 
-  const PrimaryScrollStatusBarHandler({Key key, this.child}) : super(key: key);
+  const ScrollToTopStatusBarHandler({
+    Key key,
+    @required this.child,
+    @required this.scrollController,
+  }) : super(key: key);
 
   @override
-  _PrimaryScrollWidgetState createState() => _PrimaryScrollWidgetState();
+  _ScrollToTopStatusBarState createState() => _ScrollToTopStatusBarState();
 }
 
-class _PrimaryScrollWidgetState extends State<PrimaryScrollStatusBarHandler> {
+class _ScrollToTopStatusBarState extends State<ScrollToTopStatusBarHandler> {
   @override
   void initState() {
     super.initState();
@@ -43,7 +48,7 @@ class _PrimaryScrollWidgetState extends State<PrimaryScrollStatusBarHandler> {
   }
 
   void _handleStatusBarTap(BuildContext context) {
-    final controller = PrimaryScrollController.of(context);
+    final controller = widget.scrollController;
     if (controller != null && controller.hasClients) {
       controller.animateTo(
         0.0,


### PR DESCRIPTION
This PR remove scrollController for the builder and starts using PrimaryScrollController instead

Instead of: 
```dart
showMaterialModalBottomSheet(
  context: context,
  builder: (context, scrollController) => SingleChildScrollView(scrollController: scrollController, child: Center),
)
```

it would be 
```dart
showMaterialModalBottomSheet(
  context: context,
  builder: (context) => SingleChildScrollView(primary: true, child: Center),
)
```

