### PR TITLE
Fix instance member 'opaque' can't accessed in an initalizer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.1-dev] - Fix instance member 'opaque' can't accessed in an initalizer.
+- https://github.com/jamesblasco/modal_bottom_sheet/issues/98
+
 ## [1.0.0-dev] - Improved performance and breaking change
 - The `builder` param has changed from:
 ```dart

--- a/lib/src/material_with_modal_page_route.dart
+++ b/lib/src/material_with_modal_page_route.dart
@@ -18,7 +18,6 @@ class MaterialWithModalsPageRoute<T> extends MaterialPageRoute<T> {
   })  : assert(builder != null),
         assert(maintainState != null),
         assert(fullscreenDialog != null),
-        assert(opaque),
         super(
             settings: settings,
             fullscreenDialog: fullscreenDialog,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modal_bottom_sheet
 description: 'Create awesome and powerful modal bottom sheets. Material, Cupertino iOS 13 or create your own style'
-version: 1.0.0-dev
+version: 1.0.1-dev
 homepage: 'https://github.com/jamesblasco/modal_bottom_sheet'
 
 environment:


### PR DESCRIPTION
Hello @jamesblasco,

Thanks for the package! 🎉

Fix #98 

Can you review please.