### PR TITLE
Fix a bug with latest version of Flutter.

### DIFF
--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart' show CupertinoTheme;
+import 'package:flutter/cupertino.dart' show CupertinoTheme, CupertinoApp;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart'

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -341,7 +341,8 @@ class CupertinoScaffold extends StatefulWidget {
     assert(useRootNavigator != null);
     assert(enableDrag != null);
     assert(debugCheckHasMediaQuery(context));
-    final isCupertinoApp = Theme.of(context, shadowThemeOnly: true) == null;
+    final isCupertinoApp =
+        context.findAncestorWidgetOfExactType<CupertinoApp>() != null;
     var barrierLabel = '';
     if (!isCupertinoApp) {
       assert(debugCheckHasMaterialLocalizations(context));

--- a/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -39,7 +39,7 @@ Future<T> showMaterialModalBottomSheet<T>({
       elevation: elevation,
       shape: shape,
       clipBehavior: clipBehavior,
-      theme: Theme.of(context, shadowThemeOnly: true),
+      theme: Theme.of(context),
     ),
     secondAnimationController: secondAnimation,
     bounce: bounce,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: modal_bottom_sheet
 description: 'Create awesome and powerful modal bottom sheets. Material, Cupertino iOS 13 or create your own style'
-version: 1.0.1-dev
+version: 1.1.0-dev
 homepage: 'https://github.com/jamesblasco/modal_bottom_sheet'
 
 environment:


### PR DESCRIPTION
Latest Flutter version generate a compile error with this module:

```
/path/to/Flutter/.pub-cache/hosted/pub.dartlang.org/modal_bottom_sheet-1.0.1-dev/lib/src/bottom_sheets/cupertino_bottom_sheet.dart:344:46: Error: No named parameter with the name 'shadowThemeOnly'.
    final isCupertinoApp = Theme.of(context, shadowThemeOnly: true) == null;
                                             ^^^^^^^^^^^^^^^
/path/to/Flutter/packages/flutter/lib/src/material/theme.dart:119:20: Context: Found this candidate, but the arguments don't match.
  static ThemeData of(BuildContext context) {
                   ^^
/path/to/Flutter/.pub-cache/hosted/pub.dartlang.org/modal_bottom_sheet-1.0.1-dev/lib/src/bottom_sheets/material_bottom_sheet.dart:42:32: Error: No named parameter with the name 'shadowThemeOnly'.
      theme: Theme.of(context, shadowThemeOnly: true),
                               ^^^^^^^^^^^^^^^
/path/to/Flutter/packages/flutter/lib/src/material/theme.dart:119:20: Context: Found this candidate, but the arguments don't match.
  static ThemeData of(BuildContext context) {
                   ^^

FAILURE: Build failed with an exception.
```