### PR TITLE
Let user customize sheet width

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ showMaterialModalBottomSheet(
 |bool bounce = false| The `bounce` parameter specifies if the bottom sheet can go beyond the top boundary while dragging |
 |Duration duration = const Duration(milliseconds: 400)| The `duration` of modal opening |
 |double closeProgressThreshold = 0.6| The `closeProgressThreshold` specifies when the bottom sheet will be dismissed when user drags it. |
+|double width| The `width` parameter specifies the width of the modal. If `width` is not provided, the modal will expand to the entire width. |
 
 
 #### Material params

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Flutter (1.0.0)
+  - url_launcher (0.0.1):
+    - Flutter
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  url_launcher:
+    :path: ".symlinks/plugins/url_launcher/ios"
+
+SPEC CHECKSUMS:
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
+
+PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
+
+COCOAPODS: 1.9.1

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		F49EC1A8B5B6BC4D27A5BC12 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA304D41F8973716997E8436 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,7 +32,9 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2CD26C5FF70418426645265B /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		447F7F3B9C86781BFD2A8D7B /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -42,6 +45,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AA304D41F8973716997E8436 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2DC8EF6D41DC132CBC601B4 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,12 +54,32 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F49EC1A8B5B6BC4D27A5BC12 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		61240CE9A35B080F3A615F9A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AA304D41F8973716997E8436 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8E5B350E9210EADECF5DB957 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				447F7F3B9C86781BFD2A8D7B /* Pods-Runner.debug.xcconfig */,
+				D2DC8EF6D41DC132CBC601B4 /* Pods-Runner.release.xcconfig */,
+				2CD26C5FF70418426645265B /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +97,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				8E5B350E9210EADECF5DB957 /* Pods */,
+				61240CE9A35B080F3A615F9A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -105,12 +132,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				88D7FD8FADD97B3BBA90BA26 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				79D66487B64DB3441DF6E791 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -182,6 +211,46 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		79D66487B64DB3441DF6E791 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/url_launcher/url_launcher.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		88D7FD8FADD97B3BBA90BA26 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/example/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -225,15 +225,6 @@ class _MyHomePageState extends State<MyHomePage> {
                               context: context,
                               builder: (context) => ModalWithPageView(),
                             )),
-                    ListTile(
-                        title: Text('Modal with Width'),
-                        onTap: () => showCupertinoModalBottomSheet(
-                          expand: true,
-                          width: 300,
-                          context: context,
-                          backgroundColor: Colors.transparent,
-                          builder: (context) => ModalFit(),
-                        )),
                     SizedBox(
                       height: 60,
                     )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -225,6 +225,15 @@ class _MyHomePageState extends State<MyHomePage> {
                               context: context,
                               builder: (context) => ModalWithPageView(),
                             )),
+                    ListTile(
+                        title: Text('Modal with Width'),
+                        onTap: () => showCupertinoModalBottomSheet(
+                          expand: true,
+                          width: 300,
+                          context: context,
+                          backgroundColor: Colors.transparent,
+                          builder: (context) => ModalFit(),
+                        )),
                     SizedBox(
                       height: 60,
                     )

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -225,6 +225,15 @@ class _MyHomePageState extends State<MyHomePage> {
                               context: context,
                               builder: (context) => ModalWithPageView(),
                             )),
+                    ListTile(
+                        title: Text('Cupertino Modal with Width'),
+                        onTap: () => showCupertinoModalBottomSheet(
+                          width: 300,
+                          expand: false,
+                          context: context,
+                          backgroundColor: Colors.transparent,
+                          builder: (context) => ModalFit(),
+                        )),
                     SizedBox(
                       height: 60,
                     )

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -200,4 +200,4 @@ packages:
     version: "2.1.0-nullsafety.5"
 sdks:
   dart: ">=2.12.0-29.10.beta <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -49,6 +49,7 @@ class ModalBottomSheet extends StatefulWidget {
     required this.expanded,
     required this.onClosing,
     required this.child,
+    this.width,
   })   : assert(enableDrag != null),
         assert(onClosing != null),
         assert(child != null),
@@ -106,6 +107,12 @@ class ModalBottomSheet extends StatefulWidget {
   final bool enableDrag;
 
   final ScrollController scrollController;
+
+
+  /// Width of the modal.
+  ///
+  /// Default is to expand to the devices full width.
+  final double? width;
 
   @override
   _ModalBottomSheetState createState() => _ModalBottomSheetState();

--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -365,52 +365,57 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
 
     final mediaQuery = MediaQuery.of(context);
 
-    child = AnimatedBuilder(
-      animation: widget.animationController,
-      builder: (context, Widget? child) {
-        assert(child != null);
-        final animationValue = animationCurve.transform(
-            mediaQuery.accessibleNavigation
-                ? 1.0
-                : widget.animationController.value);
+    child = Center(
+      child: Container(
+        width: widget.width,
+        child: AnimatedBuilder(
+          animation: widget.animationController,
+          builder: (context, Widget? child) {
+            assert(child != null);
+            final animationValue = animationCurve.transform(
+                mediaQuery.accessibleNavigation
+                    ? 1.0
+                    : widget.animationController.value);
 
-        final draggableChild = !widget.enableDrag
-            ? child
-            : KeyedSubtree(
-                key: _childKey,
-                child: AnimatedBuilder(
-                  animation: bounceAnimation,
-                  builder: (context, _) => CustomSingleChildLayout(
-                    delegate: _CustomBottomSheetLayout(bounceAnimation.value),
-                    child: GestureDetector(
-                      onVerticalDragUpdate: (details) {
-                        _handleDragUpdate(details.delta.dy);
-                      },
-                      onVerticalDragEnd: (details) {
-                        _handleDragEnd(details.primaryVelocity ?? 0);
-                      },
-                      child: NotificationListener<ScrollNotification>(
-                        onNotification: (ScrollNotification notification) {
-                          _handleScrollUpdate(notification);
-                          return false;
-                        },
-                        child: child!,
+            final draggableChild = !widget.enableDrag
+                ? child
+                : KeyedSubtree(
+                    key: _childKey,
+                    child: AnimatedBuilder(
+                      animation: bounceAnimation,
+                      builder: (context, _) => CustomSingleChildLayout(
+                        delegate: _CustomBottomSheetLayout(bounceAnimation.value),
+                        child: GestureDetector(
+                          onVerticalDragUpdate: (details) {
+                            _handleDragUpdate(details.delta.dy);
+                          },
+                          onVerticalDragEnd: (details) {
+                            _handleDragEnd(details.primaryVelocity ?? 0);
+                          },
+                          child: NotificationListener<ScrollNotification>(
+                            onNotification: (ScrollNotification notification) {
+                              _handleScrollUpdate(notification);
+                              return false;
+                            },
+                            child: child!,
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                  );
+            return ClipRect(
+              child: CustomSingleChildLayout(
+                delegate: _ModalBottomSheetLayout(
+                  animationValue,
+                  widget.expanded,
                 ),
-              );
-        return ClipRect(
-          child: CustomSingleChildLayout(
-            delegate: _ModalBottomSheetLayout(
-              animationValue,
-              widget.expanded,
-            ),
-            child: draggableChild,
-          ),
-        );
-      },
-      child: RepaintBoundary(child: child),
+                child: draggableChild,
+              ),
+            );
+          },
+          child: RepaintBoundary(child: child),
+        ),
+      ),
     );
 
     return ScrollToTopStatusBarHandler(
@@ -432,7 +437,7 @@ class _ModalBottomSheetLayout extends SingleChildLayoutDelegate {
       minWidth: constraints.maxWidth,
       maxWidth: constraints.maxWidth,
       minHeight: expand ? constraints.maxHeight : 0,
-      maxHeight: expand ? constraints.maxHeight : constraints.minHeight,
+      maxHeight: constraints.maxHeight,
     );
   }
 

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -19,6 +19,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
     this.expanded = false,
     this.enableDrag = true,
     this.animationCurve,
+    this.width,
   })  : assert(expanded != null),
         assert(enableDrag != null),
         super(key: key);
@@ -30,6 +31,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final bool enableDrag;
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+  final double? width;
 
   @override
   _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
@@ -117,6 +119,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 bounce: widget.bounce,
                 scrollController: scrollController,
                 animationCurve: widget.animationCurve,
+                width: widget.width,
               ),
             );
           },
@@ -142,6 +145,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.bounce = false,
     this.animationCurve,
     this.duration,
+    this.width,
     RouteSettings? settings,
   })  : assert(expanded != null),
         assert(isDismissible != null),
@@ -162,6 +166,8 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
 
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+
+  final double? width;
 
   @override
   Duration get transitionDuration => duration ?? _bottomSheetDuration;
@@ -205,6 +211,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
         bounce: bounce,
         enableDrag: enableDrag,
         animationCurve: animationCurve,
+        width: width,
       ),
     );
     return bottomSheet;

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -142,7 +142,6 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.bounce = false,
     this.animationCurve,
     this.duration,
-    this.width,
     RouteSettings? settings,
   })  : assert(expanded != null),
         assert(isDismissible != null),
@@ -160,8 +159,6 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final ScrollController? scrollController;
 
   final Duration? duration;
-
-  final double? width;
 
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -142,6 +142,7 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
     this.bounce = false,
     this.animationCurve,
     this.duration,
+    this.width,
     RouteSettings? settings,
   })  : assert(expanded != null),
         assert(isDismissible != null),
@@ -159,6 +160,8 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   final ScrollController? scrollController;
 
   final Duration? duration;
+
+  final double? width;
 
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -88,6 +88,7 @@ Future<T?> showBarModalBottomSheet<T>({
   bool enableDrag = true,
   Widget? topControl,
   Duration? duration,
+  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -117,6 +118,7 @@ Future<T?> showBarModalBottomSheet<T>({
     enableDrag: enableDrag,
     animationCurve: animationCurve,
     duration: duration,
+    width: width,
   ));
   return result;
 }

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -14,6 +14,7 @@ class BarBottomSheet extends StatelessWidget {
   final Clip? clipBehavior;
   final double? elevation;
   final ShapeBorder? shape;
+  final double? width;
 
   const BarBottomSheet({
     Key? key,
@@ -22,6 +23,7 @@ class BarBottomSheet extends StatelessWidget {
     this.clipBehavior,
     this.shape,
     this.elevation,
+    this.width,
   }) : super(key: key);
 
   @override
@@ -59,7 +61,7 @@ class BarBottomSheet extends StatelessWidget {
                 clipBehavior: clipBehavior ?? Clip.hardEdge,
                 elevation: elevation ?? 2,
                 child: SizedBox(
-                  width: double.infinity,
+                  width: width ?? double.infinity,
                   child: MediaQuery.removePadding(
                       context: context, removeTop: true, child: child),
                 ),
@@ -88,6 +90,7 @@ Future<T?> showBarModalBottomSheet<T>({
   bool enableDrag = true,
   Widget? topControl,
   Duration? duration,
+  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -108,6 +111,7 @@ Future<T?> showBarModalBottomSheet<T>({
       clipBehavior: clipBehavior,
       shape: shape,
       elevation: elevation,
+      width: width,
     ),
     secondAnimationController: secondAnimation,
     expanded: expand,
@@ -117,6 +121,7 @@ Future<T?> showBarModalBottomSheet<T>({
     enableDrag: enableDrag,
     animationCurve: animationCurve,
     duration: duration,
+    width: width,
   ));
   return result;
 }

--- a/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -14,7 +14,6 @@ class BarBottomSheet extends StatelessWidget {
   final Clip? clipBehavior;
   final double? elevation;
   final ShapeBorder? shape;
-  final double? width;
 
   const BarBottomSheet({
     Key? key,
@@ -23,7 +22,6 @@ class BarBottomSheet extends StatelessWidget {
     this.clipBehavior,
     this.shape,
     this.elevation,
-    this.width,
   }) : super(key: key);
 
   @override
@@ -61,7 +59,7 @@ class BarBottomSheet extends StatelessWidget {
                 clipBehavior: clipBehavior ?? Clip.hardEdge,
                 elevation: elevation ?? 2,
                 child: SizedBox(
-                  width: width ?? double.infinity,
+                  width: double.infinity,
                   child: MediaQuery.removePadding(
                       context: context, removeTop: true, child: child),
                 ),
@@ -90,7 +88,6 @@ Future<T?> showBarModalBottomSheet<T>({
   bool enableDrag = true,
   Widget? topControl,
   Duration? duration,
-  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -111,7 +108,6 @@ Future<T?> showBarModalBottomSheet<T>({
       clipBehavior: clipBehavior,
       shape: shape,
       elevation: elevation,
-      width: width,
     ),
     secondAnimationController: secondAnimation,
     expanded: expand,
@@ -121,7 +117,6 @@ Future<T?> showBarModalBottomSheet<T>({
     enableDrag: enableDrag,
     animationCurve: animationCurve,
     duration: duration,
-    width: width,
   ));
   return result;
 }

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -94,6 +94,7 @@ Future<T?> showCupertinoModalBottomSheet<T>({
   RouteSettings? settings,
   Color? transitionBackgroundColor,
   BoxShadow? shadow,
+  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -134,7 +135,8 @@ Future<T?> showCupertinoModalBottomSheet<T>({
         previousRouteAnimationCurve: previousRouteAnimationCurve,
         duration: duration,
         settings: settings,
-        transitionBackgroundColor: transitionBackgroundColor ?? Colors.black),
+        transitionBackgroundColor: transitionBackgroundColor ?? Colors.black,
+        width: width),
   );
   return result;
 }
@@ -150,6 +152,8 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
   // Background color behind all routes
   // Black by default
   final Color? transitionBackgroundColor;
+
+  final double? width;
 
   CupertinoModalBottomSheetRoute({
     required WidgetBuilder builder,
@@ -173,6 +177,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
     this.transitionBackgroundColor,
     this.topRadius = _kDefaultTopRadius,
     this.previousRouteAnimationCurve,
+    this.width,
   })  : assert(expanded != null),
         assert(isDismissible != null),
         assert(enableDrag != null),
@@ -191,6 +196,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
           settings: settings,
           animationCurve: animationCurve,
           duration: duration,
+          width: width,
         );
 
   @override

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -360,6 +360,7 @@ class CupertinoScaffold extends StatefulWidget {
     Duration? duration,
     RouteSettings? settings,
     BoxShadow? shadow,
+    double? width,
   }) async {
     assert(context != null);
     assert(builder != null);
@@ -397,6 +398,7 @@ class CupertinoScaffold extends StatefulWidget {
       previousRouteAnimationCurve: previousRouteAnimationCurve,
       duration: duration,
       settings: settings,
+      width: width,
     ));
     return result;
   }

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -34,6 +34,7 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
   final Color? backgroundColor;
   final Radius topRadius;
   final BoxShadow? shadow;
+  final double? width;
 
   const _CupertinoBottomSheetContainer({
     Key? key,
@@ -41,6 +42,7 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
     this.backgroundColor,
     required this.topRadius,
     this.shadow,
+    this.width,
   }) : super(key: key);
 
 
@@ -57,14 +59,17 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
       padding: EdgeInsets.only(top: topPadding),
       child: ClipRRect(
         borderRadius: BorderRadius.vertical(top: topRadius),
-        child: Container(
-          decoration:
-              BoxDecoration(color: _backgroundColor, boxShadow: [_shadow]),
-          width: double.infinity,
-          child: MediaQuery.removePadding(
-            context: context,
-            removeTop: true, //Remove top Safe Area
-            child: child,
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: Container(
+            decoration:
+                BoxDecoration(color: _backgroundColor, boxShadow: [_shadow]),
+            width: width ?? double.infinity,
+            child: MediaQuery.removePadding(
+              context: context,
+              removeTop: true, //Remove top Safe Area
+              child: child,
+            ),
           ),
         ),
       ),
@@ -94,6 +99,7 @@ Future<T?> showCupertinoModalBottomSheet<T>({
   RouteSettings? settings,
   Color? transitionBackgroundColor,
   BoxShadow? shadow,
+  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -117,6 +123,7 @@ Future<T?> showCupertinoModalBottomSheet<T>({
               backgroundColor: backgroundColor,
               topRadius: topRadius,
               shadow: shadow,
+              width: width,
             ),
         secondAnimationController: secondAnimation,
         expanded: expand,

--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -34,7 +34,6 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
   final Color? backgroundColor;
   final Radius topRadius;
   final BoxShadow? shadow;
-  final double? width;
 
   const _CupertinoBottomSheetContainer({
     Key? key,
@@ -42,7 +41,6 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
     this.backgroundColor,
     required this.topRadius,
     this.shadow,
-    this.width,
   }) : super(key: key);
 
 
@@ -59,17 +57,14 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
       padding: EdgeInsets.only(top: topPadding),
       child: ClipRRect(
         borderRadius: BorderRadius.vertical(top: topRadius),
-        child: Align(
-          alignment: Alignment.bottomCenter,
-          child: Container(
-            decoration:
-                BoxDecoration(color: _backgroundColor, boxShadow: [_shadow]),
-            width: width ?? double.infinity,
-            child: MediaQuery.removePadding(
-              context: context,
-              removeTop: true, //Remove top Safe Area
-              child: child,
-            ),
+        child: Container(
+          decoration:
+              BoxDecoration(color: _backgroundColor, boxShadow: [_shadow]),
+          width: double.infinity,
+          child: MediaQuery.removePadding(
+            context: context,
+            removeTop: true, //Remove top Safe Area
+            child: child,
           ),
         ),
       ),
@@ -99,7 +94,6 @@ Future<T?> showCupertinoModalBottomSheet<T>({
   RouteSettings? settings,
   Color? transitionBackgroundColor,
   BoxShadow? shadow,
-  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -123,7 +117,6 @@ Future<T?> showCupertinoModalBottomSheet<T>({
               backgroundColor: backgroundColor,
               topRadius: topRadius,
               shadow: shadow,
-              width: width,
             ),
         secondAnimationController: secondAnimation,
         expanded: expand,

--- a/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -20,7 +20,6 @@ Future<T?> showMaterialModalBottomSheet<T>({
   bool isDismissible = true,
   bool enableDrag = true,
   Duration? duration,
-  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -41,7 +40,6 @@ Future<T?> showMaterialModalBottomSheet<T>({
       shape: shape,
       clipBehavior: clipBehavior,
       theme: Theme.of(context),
-      width: width,
     ),
     secondAnimationController: secondAnimation,
     bounce: bounce,
@@ -62,8 +60,7 @@ WidgetWithChildBuilder _materialContainerBuilder(BuildContext context,
     double? elevation,
     ThemeData? theme,
     Clip? clipBehavior,
-    ShapeBorder? shape,
-    double? width}) {
+    ShapeBorder? shape}) {
   final bottomSheetTheme = Theme.of(context).bottomSheetTheme;
   final color = backgroundColor ??
       bottomSheetTheme.modalBackgroundColor ??
@@ -78,13 +75,7 @@ WidgetWithChildBuilder _materialContainerBuilder(BuildContext context,
       elevation: _elevation,
       shape: _shape,
       clipBehavior: _clipBehavior,
-      child: Align(
-        alignment: Alignment.bottomCenter,
-        child: Container(
-          width: width,
-          child: child,
-        ),
-      ));
+      child: child);
   if (theme != null) {
     return (context, animation, child) =>
         Theme(data: theme, child: result(context, animation, child));

--- a/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -20,6 +20,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
   bool isDismissible = true,
   bool enableDrag = true,
   Duration? duration,
+  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -50,6 +51,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
     enableDrag: enableDrag,
     animationCurve: animationCurve,
     duration: duration,
+    width: width,
   ));
   return result;
 }

--- a/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -20,6 +20,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
   bool isDismissible = true,
   bool enableDrag = true,
   Duration? duration,
+  double? width,
 }) async {
   assert(context != null);
   assert(builder != null);
@@ -40,6 +41,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
       shape: shape,
       clipBehavior: clipBehavior,
       theme: Theme.of(context),
+      width: width,
     ),
     secondAnimationController: secondAnimation,
     bounce: bounce,
@@ -60,7 +62,8 @@ WidgetWithChildBuilder _materialContainerBuilder(BuildContext context,
     double? elevation,
     ThemeData? theme,
     Clip? clipBehavior,
-    ShapeBorder? shape}) {
+    ShapeBorder? shape,
+    double? width}) {
   final bottomSheetTheme = Theme.of(context).bottomSheetTheme;
   final color = backgroundColor ??
       bottomSheetTheme.modalBackgroundColor ??
@@ -75,7 +78,13 @@ WidgetWithChildBuilder _materialContainerBuilder(BuildContext context,
       elevation: _elevation,
       shape: _shape,
       clipBehavior: _clipBehavior,
-      child: child);
+      child: Align(
+        alignment: Alignment.bottomCenter,
+        child: Container(
+          width: width,
+          child: child,
+        ),
+      ));
   if (theme != null) {
     return (context, animation, child) =>
         Theme(data: theme, child: result(context, animation, child));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -151,4 +151,4 @@ packages:
     version: "2.1.0-nullsafety.5"
 sdks:
   dart: ">=2.12.0-29.10.beta <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  flutter: ">=1.12.0"


### PR DESCRIPTION
This allows a user to set a width for their bottom sheet when calling `showCupertinoModalBottomSheet`, `showBarModalBottomSheet`, `showMaterialModalBottomSheet`, or `CupertinoScaffold.showCupertinoModalBottomSheet`. When I ran `pub get`, a bunch of files auto-updated - not sure if you want these in the PR. If not, I can just go and delete them manually.

One thing to note - if the user chooses a small width and provides a child widget that doesn't scale appropriately, flutter will get angry and throw an error. Here is an example of what I am talking about.

In the example titled "Cupertino Modal with Width", change the `width` from 300 to 50. Try to open it and note the error:
```
Leading widget consumes entire tile width. Please use a sized widget, or consider replacing ListTile with a custom widget (see https://api.flutter.dev/flutter/material/ListTile-class.html#material.ListTile.4)
'package:flutter/src/material/list_tile.dart':
Failed assertion: line 1724 pos 7: 'tileWidth != leadingSize.width || tileWidth == 0.0'
```

The problem is that the `ListTile`'s in  `example/lib/modals/modal_fit.dart` have a leading icon which is bigger than the specified width, so it throws an error. As a user, I might be confused by this error, so I just wanted to see what you think about this and if it is acceptable.

Great package and I am happy to hear that it will be integrated into flutter soon  😊
