### PR TITLE
See stackoverflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Inspired by `showModalBottomSheet`, it completes with some must-need features:
 - Support for inside scrollview + dragging down to close (`showModalBottomSheet` won't work correctly with scrollviews. 
 - Support for `WillPopScope` to prevent closing the dialog.
 - Support for scroll to top when tapping status bar (iOS only)
+- Support for top SafeArea (not supported by showModalBottomSheet)
 - Cupertino modal bottom sheet
 - Create custom modal bottom sheet
 


### PR DESCRIPTION
https://stackoverflow.com/questions/60668110/flutter-how-to-set-showmodalbottomsheet-to-full-height-but-below-status-bar