### PR TITLE
Improve fidelity for CupertinoBottomSheet

### DIFF
--- a/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -4,7 +4,15 @@
 
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart' show CupertinoTheme, CupertinoApp;
+import 'package:flutter/cupertino.dart'
+    show
+        CupertinoApp,
+        CupertinoColors,
+        CupertinoDynamicColor,
+        CupertinoTheme,
+        CupertinoThemeData,
+        CupertinoUserInterfaceLevel,
+        CupertinoUserInterfaceLevelData;
 import 'package:flutter/material.dart'
     show
         Colors,
@@ -61,7 +69,10 @@ class _CupertinoBottomSheetContainer extends StatelessWidget {
           child: MediaQuery.removePadding(
             context: context,
             removeTop: true, //Remove top Safe Area
-            child: child,
+            child: CupertinoUserInterfaceLevel(
+              data: CupertinoUserInterfaceLevelData.elevated,
+              child: child,
+            ),
           ),
         ),
       ),
@@ -271,8 +282,23 @@ class _CupertinoModalTransition extends StatelessWidget {
                   scale: scale,
                   alignment: Alignment.topCenter,
                   child: ClipRRect(
-                      borderRadius: BorderRadius.circular(radius),
-                      child: child),
+                    borderRadius: BorderRadius.circular(radius),
+                    child: CupertinoUserInterfaceLevel(
+                      data: CupertinoUserInterfaceLevelData.elevated,
+                      child: Builder(
+                        builder: (context) => CupertinoTheme(
+                          data: createPreviousRouteTheme(
+                            context,
+                            curvedAnimation,
+                          ),
+                          child: CupertinoUserInterfaceLevel(
+                            data: CupertinoUserInterfaceLevelData.base,
+                            child: child!,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
                 ),
               ),
             ],
@@ -280,6 +306,76 @@ class _CupertinoModalTransition extends StatelessWidget {
         },
       ),
     );
+  }
+
+  CupertinoThemeData createPreviousRouteTheme(
+    BuildContext context,
+    Animation<double> animation,
+  ) {
+    final cTheme = CupertinoTheme.of(context);
+
+    final systemBackground = CupertinoDynamicColor.resolve(
+      cTheme.scaffoldBackgroundColor,
+      context,
+    );
+
+    final barBackgroundColor = CupertinoDynamicColor.resolve(
+      cTheme.barBackgroundColor,
+      context,
+    );
+
+    var previousRouteTheme = cTheme;
+
+    if (cTheme.scaffoldBackgroundColor is CupertinoDynamicColor) {
+      final dynamicScaffoldBackgroundColor =
+          cTheme.scaffoldBackgroundColor as CupertinoDynamicColor;
+
+      /// BackgroundColor for the previous route with forced using
+      /// of the elevated colors
+      final elevatedScaffoldBackgroundColor =
+          CupertinoDynamicColor.withBrightnessAndContrast(
+        color: dynamicScaffoldBackgroundColor.elevatedColor,
+        darkColor: dynamicScaffoldBackgroundColor.darkElevatedColor,
+        highContrastColor:
+            dynamicScaffoldBackgroundColor.highContrastElevatedColor,
+        darkHighContrastColor:
+            dynamicScaffoldBackgroundColor.darkHighContrastElevatedColor,
+      );
+
+      previousRouteTheme = previousRouteTheme.copyWith(
+        scaffoldBackgroundColor: ColorTween(
+          begin: systemBackground,
+          end: elevatedScaffoldBackgroundColor.resolveFrom(context),
+        ).evaluate(animation),
+        primaryColor: CupertinoColors.placeholderText.resolveFrom(context),
+      );
+    }
+
+    if (cTheme.barBackgroundColor is CupertinoDynamicColor) {
+      final dynamicBarBackgroundColor =
+          cTheme.barBackgroundColor as CupertinoDynamicColor;
+
+      /// NavigationBarColor for the previous route with forced using
+      /// of the elevated colors
+      final elevatedBarBackgroundColor =
+          CupertinoDynamicColor.withBrightnessAndContrast(
+        color: dynamicBarBackgroundColor.elevatedColor,
+        darkColor: dynamicBarBackgroundColor.darkElevatedColor,
+        highContrastColor: dynamicBarBackgroundColor.highContrastElevatedColor,
+        darkHighContrastColor:
+            dynamicBarBackgroundColor.darkHighContrastElevatedColor,
+      );
+
+      previousRouteTheme = previousRouteTheme.copyWith(
+        barBackgroundColor: ColorTween(
+          begin: barBackgroundColor,
+          end: elevatedBarBackgroundColor.resolveFrom(context),
+        ).evaluate(animation),
+        primaryColor: CupertinoColors.placeholderText.resolveFrom(context),
+      );
+    }
+
+    return previousRouteTheme;
   }
 }
 


### PR DESCRIPTION
This PR is a reworked version of #44 .

This PR adds the changes discussed in #41 and #138 .

The previousRoute is now wrapped with a CupertinoUserInterfaceLevel with CupertinoUserInterfaceLevel.elevated thus the CupertinoDynamicColors automatically uses the elevatedColor. The previousRoute is also wrapped with a new CupertinoTheme which enforces elevated colors and set primaryColor to gray which previously was done by the ColorFilter. This solution should result in a smoother animation.

The seconds change I made was to wrap the child of the modal with CupertinoUserInterfaceLevel and give it also an CupertinoUserInterfaceLevel.elevated.