### PR TITLE
fix: Revert removal of hasReachedWillPopThreshold check on drag end

### DIFF
--- a/lib/src/bottom_sheet.dart
+++ b/lib/src/bottom_sheet.dart
@@ -225,7 +225,7 @@ class _ModalBottomSheetState extends State<ModalBottomSheet>
     _bounceDragController.reverse();
 
     var canClose = true;
-    if (widget.shouldClose != null) {
+    if (widget.shouldClose != null && hasReachedWillPopThreshold) {
       _cancelClose();
       canClose = await shouldClose();
     }


### PR DESCRIPTION
Removal of this check produced unwanted onWillPop calls on drag end even if the threshold was not reached.

This should fix:
* https://github.com/jamesblasco/modal_bottom_sheet/issues/229#issue-1176894265
* https://github.com/jamesblasco/modal_bottom_sheet/issues/230#issue-1181064170
And maybe:
* https://github.com/jamesblasco/modal_bottom_sheet/issues/233#issue-1183181552