### PR TITLE
fix: keep state in memory in ModalBottomSheetRoute

### DIFF
--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
     branches:
       - main
+      - master
 
 jobs:
   analyze:

--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -1,0 +1,35 @@
+name: Runnable (stable)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Analyze on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '11.x'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - name: Log Dart/Flutter versions
+        run: |
+          dart --version
+          flutter --version
+      - name: Prepare dependencies
+        run: flutter pub get
+      - name: Analyse the repo
+        run: flutter analyze lib
+      - name: Run tests
+        run: flutter test

--- a/lib/src/bottom_sheet_route.dart
+++ b/lib/src/bottom_sheet_route.dart
@@ -160,13 +160,13 @@ class ModalBottomSheetRoute<T> extends PageRoute<T> {
 
   @override
   bool get barrierDismissible => isDismissible;
-  
+
   @override
-  bool get maintainState => false; //idk but needed
+  bool get maintainState => true; // keep in memory when not active (#252)
 
   @override
   bool get opaque => false; //transparency
-  
+
   @override
   final String? barrierLabel;
 

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -1,5 +1,151 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 
 void main() {
-  test('adds one to input values', () {});
+  group(
+    'Route.mainState are well-controlled by `mainState`',
+    () {
+      testWidgets('with showCupertinoModalBottomSheet', (tester) async {
+        int _initState = 0, _dispose = 0;
+        await _pumpWidget(
+          tester: tester,
+          onPressed: (context) => showCupertinoModalBottomSheet(
+            context: context,
+            builder: (_) => _TestWidget(
+              onInitState: () => _initState++,
+              onDispose: () => _dispose++,
+            ),
+          ),
+        );
+        expect(_initState, 0);
+        await tester.tap(_textButtonWithText('Press me'));
+        await tester.pumpAndSettle();
+        expect(_initState, 1);
+        expect(_dispose, 0);
+        await tester.tap(_textButtonWithText('TestWidget push'));
+        await tester.pumpAndSettle();
+        expect(_initState, 1);
+        expect(_dispose, 0);
+        await tester.tap(_textButtonWithText('TestWidget pushed pop'));
+        await tester.pumpAndSettle();
+        expect(_initState, 1);
+        expect(_dispose, 0);
+        await tester.tap(_textButtonWithText('TestWidget pop'));
+        await tester.pumpAndSettle();
+        expect(_initState, 1);
+        expect(_dispose, 1);
+      });
+    },
+  );
+}
+
+Future<void> _pumpWidget({
+  required WidgetTester tester,
+  required void Function(BuildContext context) onPressed,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: TextButton(
+              onPressed: () => onPressed(context),
+              child: Text('Press me'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Finder _textButtonWithText(String text) {
+  return find.widgetWithText(TextButton, text);
+}
+
+class _TestWidget extends StatefulWidget {
+  const _TestWidget({
+    Key? key,
+    this.onInitState,
+    this.onDispose,
+  }) : super(key: key);
+
+  final VoidCallback? onInitState;
+  final VoidCallback? onDispose;
+
+  @override
+  State<_TestWidget> createState() => _TestWidgetState();
+}
+
+class _TestWidgetState extends State<_TestWidget> {
+  @override
+  void initState() {
+    super.initState();
+    widget.onInitState?.call();
+  }
+
+  @override
+  void dispose() {
+    widget.onDispose?.call();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          TextButton(
+            onPressed: () => Navigator.of(context).push(
+              defaultPageRoute(
+                targetPlatform: Theme.of(context).platform,
+                builder: (context) => Scaffold(
+                  body: Center(
+                    child: TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: Text('TestWidget pushed pop'),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            child: Text('TestWidget push'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text('TestWidget pop'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+PageRoute<T> defaultPageRoute<T>({
+  required TargetPlatform targetPlatform,
+  required WidgetBuilder builder,
+  RouteSettings? settings,
+  bool maintainState = true,
+  bool fullscreenDialog = false,
+}) {
+  switch (targetPlatform) {
+    case TargetPlatform.iOS:
+    case TargetPlatform.macOS:
+      return CupertinoPageRoute<T>(
+        builder: builder,
+        settings: settings,
+        maintainState: maintainState,
+        fullscreenDialog: fullscreenDialog,
+      );
+    default:
+      return MaterialPageRoute<T>(
+        builder: builder,
+        settings: settings,
+        maintainState: maintainState,
+        fullscreenDialog: fullscreenDialog,
+      );
+  }
 }

--- a/test/bottom_sheet_test.dart
+++ b/test/bottom_sheet_test.dart
@@ -7,13 +7,17 @@ void main() {
   group(
     'Route.mainState are well-controlled by `mainState`',
     () {
-      testWidgets('with showCupertinoModalBottomSheet', (tester) async {
+      Future<void> testInitStateAndDispose(
+        WidgetTester tester,
+        Future<void> Function(BuildContext context, WidgetBuilder builder)
+            onPressed,
+      ) async {
         int _initState = 0, _dispose = 0;
         await _pumpWidget(
           tester: tester,
-          onPressed: (context) => showCupertinoModalBottomSheet(
-            context: context,
-            builder: (_) => _TestWidget(
+          onPressed: (context) => onPressed(
+            context,
+            (_) => _TestWidget(
               onInitState: () => _initState++,
               onDispose: () => _dispose++,
             ),
@@ -36,6 +40,25 @@ void main() {
         await tester.pumpAndSettle();
         expect(_initState, 1);
         expect(_dispose, 1);
+      }
+
+      testWidgets('with showCupertinoModalBottomSheet', (tester) {
+        return testInitStateAndDispose(
+          tester,
+          (context, builder) => showCupertinoModalBottomSheet(
+            context: context,
+            builder: builder,
+          ),
+        );
+      });
+      testWidgets('with showMaterialModalBottomSheet', (tester) {
+        return testInitStateAndDispose(
+          tester,
+          (context, builder) => showMaterialModalBottomSheet(
+            context: context,
+            builder: builder,
+          ),
+        );
       });
     },
   );


### PR DESCRIPTION
Fix #252, #255.
Was caused by  d350f4b66fcb11c3178fc69f09005de16f9ef7d7.

`ModalBottomSheetRoute` was previously using [PopupRoute](https://github.com/flutter/flutter/blob/85684f9300/packages/flutter/lib/src/widgets/routes.dart#L1650), where `maintainState` was default to true. This fix simply reproduce this behavior.