### PR TITLE
Hide ModalBottomSheetRoute from flutter/material

### DIFF
--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ModalBottomSheetRoute;
 
 import '../modal_bottom_sheet.dart';
 

--- a/modal_bottom_sheet/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ModalBottomSheetRoute;
 import 'package:flutter/services.dart';
 
 import '../../modal_bottom_sheet.dart';

--- a/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ModalBottomSheetRoute;
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'dart:async';
 

--- a/modal_bottom_sheet/lib/src/material_with_modal_page_route.dart
+++ b/modal_bottom_sheet/lib/src/material_with_modal_page_route.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide ModalBottomSheetRoute;
 
 import '../modal_bottom_sheet.dart';
 import 'bottom_sheet_route.dart';


### PR DESCRIPTION
With the visibility change landing in https://github.com/flutter/flutter/pull/108112, this creates a name space collision with modal_bottom_sheet, as noted in #284 and #291, which means you can't use this package on the beta / master channel of flutter. 
