### PR TITLE
Fixed warnings

### DIFF
--- a/modal_bottom_sheet/example/lib/main.dart
+++ b/modal_bottom_sheet/example/lib/main.dart
@@ -260,7 +260,7 @@ class _MyHomePageState extends State<MyHomePage> {
       padding: EdgeInsets.fromLTRB(16, 20, 16, 8),
       child: Text(
         title,
-        style: Theme.of(context).textTheme.caption,
+        style: Theme.of(context).textTheme.bodySmall,
       ),
     );
   }

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -75,8 +75,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     assert(widget.route._animationController != null);
-    final scrollController = PrimaryScrollController.of(context) ??
-        (_scrollController ??= ScrollController());
+    final scrollController = PrimaryScrollController.of(context);
     return ModalScrollController(
       controller: scrollController,
       child: Builder(

--- a/modal_bottom_sheet/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -491,11 +491,6 @@ class _CupertinoScaffoldState extends State<CupertinoScaffold>
   }
 
   @override
-  void dispose() {
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return CupertinoScaffoldInheirted(
       animation: animationController,


### PR DESCRIPTION
Fixed next warnings. It should fix [ci/cd](https://github.com/jamesblasco/modal_bottom_sheet/actions/runs/4007020694/jobs/6879303676)

```bash
flutter analyze
Analyzing modal_bottom_sheet...                                         

   info • 'caption' is deprecated and shouldn't be used. Use bodySmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/main.dart:263:44 •
          deprecated_member_use
warning • The left operand can't be null, so the right operand is never executed • lib/src/bottom_sheet_route.dart:79:9 • dead_null_aware_expression
   info • Unnecessary override • lib/src/bottom_sheets/cupertino_bottom_sheet.dart:494:8 • unnecessary_overrides
```
