### PR TITLE
fix: deprecate duplicated name

### DIFF
--- a/modal_bottom_sheet/example/lib/modals/circular_modal.dart
+++ b/modal_bottom_sheet/example/lib/modals/circular_modal.dart
@@ -99,7 +99,7 @@ Future<T?> showAvatarModalBottomSheet<T>({
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
   final result = await Navigator.of(context, rootNavigator: useRootNavigator)
-      .push(modal_bottom_sheet.ModalBottomSheetRoute<T>(
+      .push(modal_bottom_sheet.ModalSheetRoute<T>(
     builder: builder,
     containerBuilder: (_, animation, child) => AvatarBottomSheet(
       child: child,

--- a/modal_bottom_sheet/example/macos/Podfile
+++ b/modal_bottom_sheet/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/modal_bottom_sheet/example/macos/Podfile.lock
+++ b/modal_bottom_sheet/example/macos/Podfile.lock
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
-  url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  url_launcher_macos: c04e4fa86382d4f94f6b38f14625708be3ae52e2
 
-PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
 COCOAPODS: 1.11.3

--- a/modal_bottom_sheet/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/modal_bottom_sheet/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -278,6 +278,7 @@
 		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -404,7 +405,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -483,7 +484,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -530,7 +531,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -19,7 +19,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   }) : super(key: key);
 
   final double? closeProgressThreshold;
-  final ModalBottomSheetRoute<T> route;
+  final ModalSheetRoute<T> route;
   final bool expanded;
   final bool bounce;
   final bool enableDrag;
@@ -122,8 +122,14 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   }
 }
 
-class ModalBottomSheetRoute<T> extends PageRoute<T> {
-  ModalBottomSheetRoute({
+@Deprecated(
+    'ModalBottomSheetRoute has been introduced in Flutter 3.7, to avoid name '
+    'conflicts, this class has been renamed to ModalSheetRoute in this '
+    'packages. ModalBottomSheetRoute will be removed in the next major version.')
+typedef ModalBottomSheetRoute<T> = ModalSheetRoute<T>;
+
+class ModalSheetRoute<T> extends PageRoute<T> {
+  ModalSheetRoute({
     this.closeProgressThreshold,
     this.containerBuilder,
     required this.builder,
@@ -211,11 +217,11 @@ class ModalBottomSheetRoute<T> extends PageRoute<T> {
 
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) =>
-      nextRoute is ModalBottomSheetRoute;
+      nextRoute is ModalSheetRoute;
 
   @override
   bool canTransitionFrom(TransitionRoute<dynamic> previousRoute) =>
-      previousRoute is ModalBottomSheetRoute || previousRoute is PageRoute;
+      previousRoute is ModalSheetRoute || previousRoute is PageRoute;
 
   Widget getPreviousRouteTransition(
     BuildContext context,
@@ -257,7 +263,7 @@ Future<T?> showCustomModalBottomSheet<T>({
       : '';
 
   final result = await Navigator.of(context, rootNavigator: useRootNavigator)
-      .push(ModalBottomSheetRoute<T>(
+      .push(ModalSheetRoute<T>(
     builder: builder,
     bounce: bounce,
     containerBuilder: containerWidget,

--- a/modal_bottom_sheet/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -98,7 +98,7 @@ Future<T?> showBarModalBottomSheet<T>({
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
   final result = await Navigator.of(context, rootNavigator: useRootNavigator)
-      .push(modal_bottom_sheet.ModalBottomSheetRoute<T>(
+      .push(modal_bottom_sheet.ModalSheetRoute<T>(
     builder: builder,
     bounce: bounce,
     closeProgressThreshold: closeProgressThreshold,

--- a/modal_bottom_sheet/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -144,7 +144,7 @@ Future<T?> showCupertinoModalBottomSheet<T>({
   return result;
 }
 
-class CupertinoModalBottomSheetRoute<T> extends ModalBottomSheetRoute<T> {
+class CupertinoModalBottomSheetRoute<T> extends ModalSheetRoute<T> {
   final Radius topRadius;
 
   final Curve? previousRouteAnimationCurve;

--- a/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -26,7 +26,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
   final result = await Navigator.of(context, rootNavigator: useRootNavigator)
-      .push(modal_bottom_sheet.ModalBottomSheetRoute<T>(
+      .push(modal_bottom_sheet.ModalSheetRoute<T>(
     builder: builder,
     closeProgressThreshold: closeProgressThreshold,
     containerBuilder: _materialContainerBuilder(

--- a/modal_bottom_sheet/lib/src/material_with_modal_page_route.dart
+++ b/modal_bottom_sheet/lib/src/material_with_modal_page_route.dart
@@ -19,7 +19,7 @@ class MaterialWithModalsPageRoute<T> extends MaterialPageRoute<T> {
             builder: builder,
             maintainState: maintainState);
 
-  modal_bottom_sheet.ModalBottomSheetRoute? _nextModalRoute;
+  modal_bottom_sheet.ModalSheetRoute? _nextModalRoute;
 
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
@@ -28,12 +28,12 @@ class MaterialWithModalsPageRoute<T> extends MaterialPageRoute<T> {
         (nextRoute is CupertinoPageRoute && !nextRoute.fullscreenDialog) ||
         (nextRoute is MaterialWithModalsPageRoute &&
             !nextRoute.fullscreenDialog) ||
-        (nextRoute is modal_bottom_sheet.ModalBottomSheetRoute);
+        (nextRoute is modal_bottom_sheet.ModalSheetRoute);
   }
 
   @override
   void didChangeNext(Route? nextRoute) {
-    if (nextRoute is modal_bottom_sheet.ModalBottomSheetRoute) {
+    if (nextRoute is modal_bottom_sheet.ModalSheetRoute) {
       _nextModalRoute = nextRoute;
     }
 


### PR DESCRIPTION
- Renames ModalBottomSheetRoute to ModalSheetRoute to avoid duplicated name in Flutter 3.7