### PR TITLE
CupertinoExtendedPage and MaterialExtendedPage blocking navigation (sheet:1.0.0-pre) 

### DIFF
--- a/sheet/lib/src/route/base_route_extended.dart
+++ b/sheet/lib/src/route/base_route_extended.dart
@@ -73,7 +73,7 @@ class _PageBasedMaterialPageRoute<T> extends MaterialExtendedPageRoute<T> {
 
   @override
   Widget buildContent(BuildContext context) {
-    return builder(context);
+    return _page.child;
   }
 
   @override
@@ -150,7 +150,7 @@ class _PageBasedCupertinoPageRoute<T> extends CupertinoExtendedPageRoute<T> {
 
   @override
   Widget buildContent(BuildContext context) {
-    return builder(context);
+    return _page.child;
   }
 
   @override

--- a/sheet/test/src/route/base_route_extended_test.dart
+++ b/sheet/test/src/route/base_route_extended_test.dart
@@ -55,6 +55,36 @@ void main() {
       expect(find.text('child'), findsOneWidget);
     });
 
+    testWidgets('navigating to different routes keeping the same page',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        builder: (context, child) {
+          return Navigator(
+            pages: [
+              MaterialExtendedPage(child: Text('first child')),
+            ],
+            onPopPage: (route, result) => false,
+          );
+        },
+      ));
+      await tester.pumpAndSettle();
+      expect(find.text('first child'), findsOneWidget);
+
+      await tester.pumpWidget(MaterialApp(
+        builder: (context, child) {
+          return Navigator(
+            pages: [
+              MaterialExtendedPage(child: Text('second child')),
+            ],
+            onPopPage: (route, result) => false,
+          );
+        },
+      ));
+
+      await tester.pumpAndSettle();
+      expect(find.text('second child'), findsOneWidget);
+    });
+
     testWidgets('route is a MaterialExtendedPageRoute',
         (WidgetTester tester) async {
       await tester.pumpWidget(MaterialApp(
@@ -154,6 +184,36 @@ void main() {
       ));
       await tester.pumpAndSettle();
       expect(find.text('child'), findsOneWidget);
+    });
+
+    testWidgets('navigating to different routes keeping the same page',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+        builder: (context, child) {
+          return Navigator(
+            pages: [
+              CupertinoExtendedPage(child: Text('first child')),
+            ],
+            onPopPage: (route, result) => false,
+          );
+        },
+      ));
+      await tester.pumpAndSettle();
+      expect(find.text('first child'), findsOneWidget);
+
+      await tester.pumpWidget(MaterialApp(
+        builder: (context, child) {
+          return Navigator(
+            pages: [
+              CupertinoExtendedPage(child: Text('second child')),
+            ],
+            onPopPage: (route, result) => false,
+          );
+        },
+      ));
+
+      await tester.pumpAndSettle();
+      expect(find.text('second child'), findsOneWidget);
     });
 
     testWidgets('route is a CupertinoExtendedPageRoute',


### PR DESCRIPTION
Fixes [issue-343](https://github.com/jamesblasco/modal_bottom_sheet/issues/343).
