### PR TITLE
Minor: ScrollController's on(Attach|Detach) arguments for scroll activity tracking

### DIFF
--- a/sheet/lib/src/sheet.dart
+++ b/sheet/lib/src/sheet.dart
@@ -317,7 +317,11 @@ class _DefaultSheetScrollController extends StatelessWidget {
 ///  * [SheetPosition], which manages the positioning logic for
 ///    this controller.
 class SheetController extends ScrollController {
-  SheetController({super.debugLabel}) : super(initialScrollOffset: 0);
+  SheetController({
+    super.debugLabel,
+    super.onAttach,
+    super.onDetach,
+  }) : super(initialScrollOffset: 0);
 
   final ProxyAnimation _animation = ProxyAnimation();
   Animation<double> get animation => _animation;


### PR DESCRIPTION
I'd like to know if the sheet is currently being scrolled. Since I couldn't find any other way (happy to hear otherwise), I'd like to listen to the ScrollPosition.isScrollingNotifier. You'd normally set this up in the `void Function(ScrollPosition) onAttach` callback. As such, I'd like to expose it.  I also exposed the onDispose, mostly since I was on it and it seems useful enough :handwave: 