### PR TITLE
Fixes #228: BottomSheetRoute throws if declared as initial route

### DIFF
--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -180,7 +180,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
   AnimationController createAnimationController() {
     assert(_animationController == null);
     _animationController = ModalBottomSheet.createAnimationController(
-      navigator!.overlay!,
+      navigator!,
       duration: transitionDuration,
     );
     return _animationController!;


### PR DESCRIPTION
Fixes: https://github.com/jamesblasco/modal_bottom_sheet/issues/228

If you set your initial route to a page that uses a ModalBottomSheetRoute, it will cause a crash.

This prevents that crash.