### PR TITLE
fix(sheet): adapt scrollable.dart to upstream SemanticsNode changes

### DIFF
--- a/sheet/lib/src/scrollable.dart
+++ b/sheet/lib/src/scrollable.dart
@@ -866,10 +866,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
       return;
     }
 
-    _innerNode ??= SemanticsNode(showOnScreen: showOnScreen);
-    _innerNode!
-      ..isMergedIntoParent = node.isPartOfNodeMerging
-      ..rect = node.rect;
+    (_innerNode ??= SemanticsNode(showOnScreen: showOnScreen)).rect = node.rect;
 
     int? firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];


### PR DESCRIPTION
This PR https://github.com/flutter/flutter/pull/137304 makes SemanticsNode.isMergedIntoParent readonly, which makes the customized scrollable.dart incompatible when using flutter version 3.18 and upwards