### PR TITLE
Allow resizing sheet larger than minResizableExtent when resizable is true

### DIFF
--- a/sheet/lib/src/widgets/resizable_sheet.dart
+++ b/sheet/lib/src/widgets/resizable_sheet.dart
@@ -118,27 +118,15 @@ class RenderResizableSheetChildBox extends RenderShiftedBox {
       return;
     }
 
-    // The height of the child will be the maximun between the offset pixels
+    // The height of the child will be the maximum between the offset pixels
     // and the minExtent
-    final double extent = max(_offset.pixels, minExtent);
-
+    final double extend = max(_offset.pixels, minExtent);
     child!.layout(
-      BoxConstraints(
-        maxHeight: extent,
-        minHeight: extent,
-        minWidth: constraints.minWidth,
-        maxWidth: constraints.maxWidth,
-      ),
+      constraints.copyWith(maxHeight: extend, minHeight: extend),
       parentUsesSize: true,
     );
 
-    if (!constraints.hasTightHeight) {
-      size = Size(
-          child!.size.width, constraints.constrainHeight(child!.size.height));
-      childParentData.offset = Offset.zero;
-    } else {
-      size = constraints.biggest;
-      childParentData.offset = Offset.zero;
-    }
+    size = constraints.biggest;
+    childParentData.offset = Offset.zero;
   }
 }


### PR DESCRIPTION
https://github.com/jamesblasco/modal_bottom_sheet/issues/410

### Pull Request Description:

Apply `resizable` in the `sheet`'s `performLayout`.

#### Changes:
- Pass `resizable` down to the parent `performLayout`
- Modify `performLayout` to use the biggest constraint when `resizable` is true.
