### PR TITLE
Improve Cupertino Sheet Scroll Behavior

### DIFF
--- a/sheet/lib/src/physics.dart
+++ b/sheet/lib/src/physics.dart
@@ -139,6 +139,10 @@ class BouncingSheetPhysics extends ScrollPhysics with SheetPhysics {
       }
       return true;
     }());
+    // Prevent scrolling beyond the maximum position
+    if (value > position.maxScrollExtent) {
+      return value - position.maxScrollExtent;
+    }
     if (!overflowViewport) {
       // overscroll
       if (position.viewportDimension <= position.pixels &&


### PR DESCRIPTION
# Improve Cupertino Sheet Scroll Behavior

## Description
This PR addresses an issue with the `Sheet` widget where unintended overscroll at the top was causing usability problems. While this solution doesn't perfectly replicate native iOS behavior, it provides a quick win to make the sheet more usable and prevent content expansion issues.

## Changes
- Adjusted `applyBoundaryConditions` method to clamp the scroll position at the top

## How Has This Been Tested?
- Manual testing with various scroll scenarios
- Verified that the sheet stops correctly at the top position

## Related Issues
Partially addresses:
- #345 
- #298 
