### PR TITLE
Fixed issue with closeProgressThreshold for smaller bottom sheets

### DIFF
--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -45,7 +45,7 @@ class ModalBottomSheet extends StatefulWidget {
     required this.expanded,
     required this.onClosing,
     required this.child,
-    this.minFlingVelocity = _minFlingVelocity,
+    double? minFlingVelocity,
     double? closeProgressThreshold,
     @Deprecated('Use preventPopThreshold instead') double? willPopThreshold,
     double? preventPopThreshold,
@@ -54,7 +54,8 @@ class ModalBottomSheet extends StatefulWidget {
   })  : preventPopThreshold =
             preventPopThreshold ?? willPopThreshold ?? _willPopThreshold,
         closeProgressThreshold =
-            closeProgressThreshold ?? _closeProgressThreshold;
+            closeProgressThreshold ?? _closeProgressThreshold,
+        minFlingVelocity = minFlingVelocity ?? _minFlingVelocity;
 
   /// The closeProgressThreshold parameter
   /// specifies when the bottom sheet will be dismissed when user drags it.

--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -143,6 +143,24 @@ class ModalBottomSheet extends StatefulWidget {
       vsync: vsync,
     );
   }
+
+  static ModalBottomSheetState of(BuildContext context) {
+    ModalBottomSheetState? sheetState;
+    if (context is StatefulElement && context.state is ModalBottomSheetState) {
+      sheetState = context.state as ModalBottomSheetState;
+    }
+    sheetState = sheetState ?? context.findAncestorStateOfType<ModalBottomSheetState>();
+
+    assert(() {
+      if (sheetState == null) {
+        throw FlutterError(
+          'No ModalBottomSheetState in the widget tree',
+        );
+      }
+      return true;
+    }());
+    return sheetState!;
+  }
 }
 
 class ModalBottomSheetState extends State<ModalBottomSheet>
@@ -179,6 +197,15 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
   // when we start a drag event, we are always scrollable
   bool _canScroll = true;
   bool _isScrolling = false;
+  bool _allowDrag = true;
+
+  // Lets us set if dragging is allowed from userSpace
+  // ModalBottomSheet.of(context).setAllowDrag(false)
+  void setAllowDrag(bool allowDrag) {
+    _allowDrag = allowDrag;
+  }
+
+
   ScrollDirection _scrollDirection = ScrollDirection.idle;
 
   bool get hasReachedWillPopThreshold =>
@@ -243,6 +270,10 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
     assert(widget.enableDrag, 'Dragging is disabled');
 
     if (_dismissUnderway) {
+      return;
+    }
+
+    if (!_allowDrag) {
       return;
     }
 

--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -181,7 +181,6 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
     // the height difference between the viewport and the content
     final closeProgressThreshold = widget.closeProgressThreshold;
 
-    // Interpolate the value intop between 1 and the lower bound
     final value = (widget.animationController.value - _lowerBound) / (1 - _lowerBound);
 
     return value < closeProgressThreshold;

--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -178,6 +178,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
   // Indicates if the scrollbar is scrollable
   // when we start a drag event, we are always scrollable
   bool _canScroll = true;
+  bool _isScrolling = false;
   ScrollDirection _scrollDirection = ScrollDirection.idle;
 
   bool get hasReachedWillPopThreshold =>
@@ -246,7 +247,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
     }
 
     // Abort if the scrollbar is scrollable
-    if (_canScroll && _scrollController.hasClients && _scrollController.position.maxScrollExtent > 0) {
+    if (_canScroll && _isScrolling) {
       return;
     }
 
@@ -331,6 +332,12 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
 
     if (notification is UserScrollNotification) {
       _scrollDirection = notification.direction;
+    }
+
+    if (notification is ScrollEndNotification) {
+      _isScrolling = false;
+    } else if (notification is ScrollStartNotification){
+      _isScrolling = true;
     }
 
     if (notification is OverscrollNotification || notification is ScrollUpdateNotification) {

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -16,6 +16,8 @@ class _ModalBottomSheet<T> extends StatefulWidget {
     this.expanded = false,
     this.enableDrag = true,
     this.animationCurve,
+    this.scrollPhysics,
+    this.scrollPhysicsBuilder,
   });
 
   final double? closeProgressThreshold;
@@ -25,6 +27,8 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final bool enableDrag;
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+  final ScrollPhysics? scrollPhysics;
+  final ScrollPhysics Function(bool canScroll, ScrollPhysics parent)? scrollPhysicsBuilder;
 
   @override
   _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
@@ -123,6 +127,8 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 bounce: widget.bounce,
                 scrollController: scrollController,
                 animationCurve: widget.animationCurve,
+                scrollPhysics: widget.scrollPhysics,
+                scrollPhysicsBuilder: widget.scrollPhysicsBuilder,
               ),
             );
           },
@@ -148,6 +154,8 @@ class ModalSheetRoute<T> extends PageRoute<T> {
     this.bounce = false,
     this.animationCurve,
     Duration? duration,
+    this.scrollPhysics,
+    this.scrollPhysicsBuilder,
     super.settings,
   }) : duration = duration ?? _bottomSheetDuration;
 
@@ -165,6 +173,9 @@ class ModalSheetRoute<T> extends PageRoute<T> {
 
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+
+  final ScrollPhysics? scrollPhysics;
+  final ScrollPhysics Function(bool canScroll, ScrollPhysics parent)? scrollPhysicsBuilder;
 
   @override
   Duration get transitionDuration => duration;
@@ -215,6 +226,8 @@ class ModalSheetRoute<T> extends PageRoute<T> {
         bounce: bounce,
         enableDrag: enableDrag,
         animationCurve: animationCurve,
+        scrollPhysics: scrollPhysics,
+        scrollPhysicsBuilder: scrollPhysicsBuilder,
       ),
     );
     return bottomSheet;

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -18,8 +18,10 @@ class _ModalBottomSheet<T> extends StatefulWidget {
     this.animationCurve,
     this.scrollPhysics,
     this.scrollPhysicsBuilder,
+    this.minFlingVelocity,
   });
 
+  final double? minFlingVelocity;
   final double? closeProgressThreshold;
   final ModalSheetRoute<T> route;
   final bool expanded;
@@ -100,6 +102,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 expanded: widget.route.expanded,
                 containerBuilder: widget.route.containerBuilder,
                 animationController: widget.route._animationController!,
+                minFlingVelocity: widget.minFlingVelocity,
                 shouldClose: widget.route.popDisposition ==
                             RoutePopDisposition.doNotPop ||
                         widget.route._hasScopedWillPopCallback
@@ -142,6 +145,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 class ModalSheetRoute<T> extends PageRoute<T> {
   ModalSheetRoute({
     this.closeProgressThreshold,
+    this.minFlingVelocity,
     this.containerBuilder,
     required this.builder,
     this.scrollController,
@@ -160,6 +164,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
   }) : duration = duration ?? _bottomSheetDuration;
 
   final double? closeProgressThreshold;
+  final double? minFlingVelocity;
   final WidgetWithChildBuilder? containerBuilder;
   final WidgetBuilder builder;
   final bool expanded;
@@ -219,6 +224,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
       context: context,
       // removeTop: true,
       child: _ModalBottomSheet<T>(
+        minFlingVelocity: minFlingVelocity,
         closeProgressThreshold: closeProgressThreshold,
         route: this,
         secondAnimationController: secondAnimationController,
@@ -270,6 +276,7 @@ Future<T?> showCustomModalBottomSheet<T>({
   Duration? duration,
   RouteSettings? settings,
   double? closeProgressThreshold,
+  double? minFlingVelocity,
 }) async {
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -295,6 +302,7 @@ Future<T?> showCustomModalBottomSheet<T>({
     duration: duration,
     settings: settings,
     closeProgressThreshold: closeProgressThreshold,
+    minFlingVelocity: minFlingVelocity,
   ));
   return result;
 }

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -160,6 +160,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
     Duration? duration,
     this.scrollPhysics,
     this.scrollPhysicsBuilder,
+    super.fullscreenDialog,
     super.settings,
   }) : duration = duration ?? _bottomSheetDuration;
 


### PR DESCRIPTION
When a ModalBottomSheets that due to its content is smaller than a full screen bottom sheet, the user has to move the dialog almost to the bottom of the screen before it dismisses. This is because the closeProgressThreshold calculates the threshold based on the viewport size and not the size of the rendered bottom sheet.

We need to adjust for this based on the height difference of the viewport and the rendered content within the bottom sheet dialog

Related issue: #421