### PR TITLE
fix(SheetPrimaryScrollPosition): ScrollSpringSimulation end point is …

### DIFF
--- a/sheet/lib/src/scroll_controller.dart
+++ b/sheet/lib/src/scroll_controller.dart
@@ -146,7 +146,7 @@ class SheetPrimaryScrollPosition extends ScrollPositionWithSingleContext {
               ratio: 1.1,
             ),
             pixels,
-            0,
+            pixels > maxScrollExtent ? maxScrollExtent : 0,
             velocity,
           ),
           context.vsync,


### PR DESCRIPTION
### BUG FIX

Using `CupertinoSheetRoute` may cause unexpected scroll behavior.

### STEPS TO REPRODUCE

1. Run the provided example and open the sheet.
2. Scroll down to the very bottom of the list, and during the bouncing effect, tap on an item (refer to the attached video).
3. The list scrolls up unexpectedly 

https://github.com/user-attachments/assets/2d169e43-71c1-4e9f-9891-078fd44e4a49


```dart

import 'package:flutter/material.dart';
import 'package:sheet/route.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Material App',
      home: Scaffold(
        body: Center(
          child: Builder(
            builder: (context) {
              return TextButton(
                onPressed: () {
                  Navigator.of(context).push(
                    CupertinoSheetRoute<void>(
                      builder: (BuildContext context) =>
                          const CupertinoSheetWithScrollableList(),
                    ),
                  );
                },
                child: const Text('Open Sheet'),
              );
            },
          ),
        ),
      ),
    );
  }
}

class CupertinoSheetWithScrollableList extends StatelessWidget {
  const CupertinoSheetWithScrollableList({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: ListView(
        children: ListTile.divideTiles(
          context: context,
          tiles: List<Widget>.generate(
            100,
            (int index) => ListTile(
              title: Text('Item $index'),
            ),
          ),
        ).toList(),
      ),
    );
  }
}

```

This pull request includes a change to the `SheetPrimaryScrollPosition` class in the `sheet/lib/src/scroll_controller.dart` file. The change ensures that the `pixels` value does not exceed the `maxScrollExtent`.

