### PR TITLE
[Sheet] PopScope - fix `onPopInvoked` usage in `preventPop`

### DIFF
--- a/sheet/example/lib/examples/route/navigation/go_router_pop_scope.dart
+++ b/sheet/example/lib/examples/route/navigation/go_router_pop_scope.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sheet/route.dart';
+
+class GoRouterPopScopeApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'PopScope Example',
+      routerConfig: _router,
+      theme: ThemeData.light(),
+    );
+  }
+
+  final GoRouter _router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) => HomeScreen(),
+        routes: [
+          GoRoute(
+            path: 'detail',
+            pageBuilder: (_, __) => SheetPage(child: DetailScreen()),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+class HomeScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CupertinoNavigationBar(
+        leading: BackButton(onPressed: () => Navigator.of(context, rootNavigator: true).pop()),
+        middle: Text('Home')
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => context.go('/detail'),
+          child: Text('Open Sheet'),
+        ),
+      ),
+    );
+  }
+}
+
+class DetailScreen extends StatefulWidget {
+  @override
+  State<DetailScreen> createState() => _DetailScreenState();
+}
+
+class _DetailScreenState extends State<DetailScreen> {
+  bool canPop = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: canPop,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        if (await _confirmExit(context)) Navigator.pop(context, result);
+      },
+      child: Scaffold(
+        appBar: CupertinoNavigationBar(middle: Text('Detail')),
+        body: Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text("canPop"),
+              Switch(value: canPop, onChanged: (value) => setState(() => canPop = value)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<bool> _confirmExit(BuildContext context) async {
+    return await showCupertinoModalPopup(
+          context: context,
+          builder: (context) => CupertinoActionSheet(
+            title: Text('Should Close?'),
+            actions: [
+              CupertinoActionSheetAction(
+                isDestructiveAction: true,
+                onPressed: () => Navigator.pop(context, true),
+                child: Text('OK'),
+              ),
+              CupertinoActionSheetAction(
+                onPressed: () => Navigator.pop(context, false),
+                child: Text('Cancel'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+}

--- a/sheet/example/lib/route_example_page.dart
+++ b/sheet/example/lib/route_example_page.dart
@@ -20,6 +20,7 @@ import 'package:sheet/sheet.dart';
 import 'examples/route/examples/modal_with_nested_scroll.dart';
 import 'examples/route/navigation/go_router.dart';
 import 'examples/route/navigation/go_router_advanced.dart';
+import 'examples/route/navigation/go_router_pop_scope.dart';
 
 class RouteExamplePage extends StatelessWidget {
   const RouteExamplePage({super.key});
@@ -92,6 +93,16 @@ class RouteExamplePage extends StatelessWidget {
                           fullscreenDialog: true,
                           builder: (BuildContext context) =>
                               AdvancedGoRouterBooksApp(),
+                        ),
+                      ),
+                    ),
+                    ListTile(
+                      title: const Text('Go router - PopScope'),
+                      onTap: () => Navigator.of(context).push(
+                        MaterialExtendedPageRoute<void>(
+                          fullscreenDialog: true,
+                          builder: (BuildContext context) =>
+                              GoRouterPopScopeApp(),
                         ),
                       ),
                     ),

--- a/sheet/lib/src/route/sheet_route.dart
+++ b/sheet/lib/src/route/sheet_route.dart
@@ -469,6 +469,7 @@ class __SheetRouteContainerState extends State<_SheetRouteContainer>
     );
     if (route.popDisposition == RoutePopDisposition.doNotPop) {
       _sheetController.position.stopPreventingDrag();
+      _firstAnimation = true;
       route.onPopInvokedWithResult(false, null);
     } else {
       route.willPop().then(

--- a/sheet/lib/src/route/sheet_route.dart
+++ b/sheet/lib/src/route/sheet_route.dart
@@ -469,7 +469,7 @@ class __SheetRouteContainerState extends State<_SheetRouteContainer>
     );
     if (route.popDisposition == RoutePopDisposition.doNotPop) {
       _sheetController.position.stopPreventingDrag();
-      route.onPopInvoked(false);
+      route.onPopInvokedWithResult(false, null);
     } else {
       route.willPop().then(
         (RoutePopDisposition disposition) {


### PR DESCRIPTION
## Problem  
The `onPopInvoked` method in `Route` [is deprecated](https://api.flutter.dev/flutter/widgets/Form/onPopInvoked.html) and no longer triggers pop handling, which prevents `onPopInvokedWithResult` in `PopScope` from being called. As a result, `PopScope` does not properly intercept back navigation when using `SheetRoute` and derived classes. 

### Before
https://github.com/user-attachments/assets/d60956d0-76d9-41e1-b06b-1eba988dab8f  
### After
https://github.com/user-attachments/assets/ef7f775a-af34-43cd-a110-926ce8648487


## Solution  
Updated `preventPop` to call `onPopInvokedWithResult` instead of the deprecated `onPopInvoked`.

## Changes  
- Replaced `route.onPopInvoked(false)` with `route.onPopInvokedWithResult(false, null)` in `preventPop`.  

## Evidence  
- Added a `PopScope` example to the project for future testing.  

🚀  
