### PR TITLE
make preventPopThreshold configurable and PopScope can be closed by dragging when it's popped.

### DIFF
--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -45,6 +45,7 @@ class ModalBottomSheet extends StatefulWidget {
     required this.onClosing,
     required this.child,
     this.minFlingVelocity = _minFlingVelocity,
+    this.onDragStateChanged,
     double? closeProgressThreshold,
     @Deprecated('Use preventPopThreshold instead') double? willPopThreshold,
     double? preventPopThreshold,
@@ -114,6 +115,8 @@ class ModalBottomSheet extends StatefulWidget {
   /// Determines how far the sheet should be flinged before closing.
   final double preventPopThreshold;
 
+  final bool Function(bool isDragging)? onDragStateChanged;
+
   @override
   ModalBottomSheetState createState() => ModalBottomSheetState();
 
@@ -165,6 +168,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
 
   void _close() {
     isDragging = false;
+    widget.onDragStateChanged?.call(isDragging);
     widget.onClosing();
   }
 
@@ -198,6 +202,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
 
     if (_dismissUnderway) return;
     isDragging = true;
+    widget.onDragStateChanged?.call(isDragging);
 
     final progress = primaryDelta / (_childHeight ?? primaryDelta);
 
@@ -234,6 +239,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
 
     if (_dismissUnderway || !isDragging) return;
     isDragging = false;
+    widget.onDragStateChanged?.call(isDragging);
     _bounceDragController.reverse();
 
     Future<void> tryClose() async {

--- a/modal_bottom_sheet/lib/src/bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet.dart
@@ -158,7 +158,7 @@ class ModalBottomSheetState extends State<ModalBottomSheet>
   bool isDragging = false;
 
   bool get hasReachedWillPopThreshold =>
-      widget.animationController.value < _willPopThreshold;
+      widget.animationController.value < widget.preventPopThreshold;
 
   bool get hasReachedCloseThreshold =>
       widget.animationController.value < widget.closeProgressThreshold;

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -52,6 +52,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
   }
 
   ScrollController? _scrollController;
+  bool _isDragging = false;
 
   @override
   void initState() {
@@ -99,6 +100,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 containerBuilder: widget.route.containerBuilder,
                 animationController: widget.route._animationController!,
                 preventPopThreshold: widget.preventPopThreshold,
+                onDragStateChanged: (v) => _isDragging = v,
                 shouldClose: widget.route.popDisposition ==
                             RoutePopDisposition.doNotPop ||
                         widget.route._hasScopedWillPopCallback
@@ -111,6 +113,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                                 popDisposition == RoutePopDisposition.doNotPop);
                         popDisposition == RoutePopDisposition.doNotPop;
                         if (!shouldClose) {
+                          if (_isDragging) return false;
                           // ignore: deprecated_member_use
                           widget.route.onPopInvoked(false);
                           widget.route.onPopInvokedWithResult(false, null);
@@ -189,7 +192,8 @@ class ModalSheetRoute<T> extends PageRoute<T> {
   final String? barrierLabel;
 
   @override
-  Color get barrierColor => modalBarrierColor ?? Colors.black.withValues(alpha: 0.35);
+  Color get barrierColor =>
+      modalBarrierColor ?? Colors.black.withValues(alpha: 0.35);
 
   final double? preventPopThreshold;
 

--- a/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheet_route.dart
@@ -10,6 +10,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   const _ModalBottomSheet({
     super.key,
     this.closeProgressThreshold,
+    this.preventPopThreshold,
     required this.route,
     this.secondAnimationController,
     this.bounce = false,
@@ -25,6 +26,7 @@ class _ModalBottomSheet<T> extends StatefulWidget {
   final bool enableDrag;
   final AnimationController? secondAnimationController;
   final Curve? animationCurve;
+  final double? preventPopThreshold;
 
   @override
   _ModalBottomSheetState<T> createState() => _ModalBottomSheetState<T>();
@@ -96,6 +98,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                 expanded: widget.route.expanded,
                 containerBuilder: widget.route.containerBuilder,
                 animationController: widget.route._animationController!,
+                preventPopThreshold: widget.preventPopThreshold,
                 shouldClose: widget.route.popDisposition ==
                             RoutePopDisposition.doNotPop ||
                         widget.route._hasScopedWillPopCallback
@@ -108,7 +111,10 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
                                 popDisposition == RoutePopDisposition.doNotPop);
                         popDisposition == RoutePopDisposition.doNotPop;
                         if (!shouldClose) {
+                          // ignore: deprecated_member_use
                           widget.route.onPopInvoked(false);
+                          widget.route.onPopInvokedWithResult(false, null);
+                          return !widget.route.isCurrent;
                         }
                         return shouldClose;
                       }
@@ -136,6 +142,7 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
 class ModalSheetRoute<T> extends PageRoute<T> {
   ModalSheetRoute({
     this.closeProgressThreshold,
+    this.preventPopThreshold,
     this.containerBuilder,
     required this.builder,
     this.scrollController,
@@ -182,7 +189,9 @@ class ModalSheetRoute<T> extends PageRoute<T> {
   final String? barrierLabel;
 
   @override
-  Color get barrierColor => modalBarrierColor ?? Colors.black.withOpacity(0.35);
+  Color get barrierColor => modalBarrierColor ?? Colors.black.withValues(alpha: 0.35);
+
+  final double? preventPopThreshold;
 
   AnimationController? _animationController;
 
@@ -209,6 +218,7 @@ class ModalSheetRoute<T> extends PageRoute<T> {
       // removeTop: true,
       child: _ModalBottomSheet<T>(
         closeProgressThreshold: closeProgressThreshold,
+        preventPopThreshold: preventPopThreshold,
         route: this,
         secondAnimationController: secondAnimationController,
         expanded: expanded,

--- a/modal_bottom_sheet/lib/src/bottom_sheets/bar_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/bar_bottom_sheet.dart
@@ -93,6 +93,7 @@ Future<T?> showBarModalBottomSheet<T>({
   RouteSettings? settings,
   SystemUiOverlayStyle? overlayStyle,
   double? closeProgressThreshold,
+  double? preventPopThreshold,
 }) async {
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -101,6 +102,7 @@ Future<T?> showBarModalBottomSheet<T>({
     builder: builder,
     bounce: bounce,
     closeProgressThreshold: closeProgressThreshold,
+    preventPopThreshold: preventPopThreshold,
     containerBuilder: (_, __, child) => BarBottomSheet(
       child: child,
       control: topControl,

--- a/modal_bottom_sheet/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/cupertino_bottom_sheet.dart
@@ -120,6 +120,7 @@ Future<T?> showCupertinoModalBottomSheet<T>({
   BoxShadow? shadow,
   SystemUiOverlayStyle? overlayStyle,
   double? closeProgressThreshold,
+  double? preventPopThreshold,
 }) async {
   assert(debugCheckHasMediaQuery(context));
   final hasMaterialLocalizations =
@@ -142,6 +143,7 @@ Future<T?> showCupertinoModalBottomSheet<T>({
         secondAnimationController: secondAnimation,
         expanded: expand,
         closeProgressThreshold: closeProgressThreshold,
+        preventPopThreshold: preventPopThreshold,
         barrierLabel: barrierLabel,
         elevation: elevation,
         bounce: bounce,
@@ -180,6 +182,7 @@ class CupertinoModalBottomSheetRoute<T> extends ModalSheetRoute<T> {
     required super.builder,
     super.containerBuilder,
     super.closeProgressThreshold,
+    super.preventPopThreshold,
     super.barrierLabel,
     double? elevation,
     ShapeBorder? shape,
@@ -433,6 +436,7 @@ class CupertinoScaffold extends StatefulWidget {
   static Future<T?> showCupertinoModalBottomSheet<T>({
     required BuildContext context,
     double? closeProgressThreshold,
+    double? preventPopThreshold,
     required WidgetBuilder builder,
     Curve? animationCurve,
     Curve? previousRouteAnimationCurve,
@@ -466,6 +470,7 @@ class CupertinoScaffold extends StatefulWidget {
     final result = await Navigator.of(context, rootNavigator: useRootNavigator)
         .push(CupertinoModalBottomSheetRoute<T>(
       closeProgressThreshold: closeProgressThreshold,
+      preventPopThreshold: preventPopThreshold,
       builder: builder,
       secondAnimationController: CupertinoScaffold.of(context)!.animation,
       containerBuilder: (context, _, child) => _CupertinoBottomSheetContainer(

--- a/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
+++ b/modal_bottom_sheet/lib/src/bottom_sheets/material_bottom_sheet.dart
@@ -22,6 +22,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
   Duration? duration,
   RouteSettings? settings,
   double? closeProgressThreshold,
+  double? preventPopThreshold,
 }) async {
   assert(debugCheckHasMediaQuery(context));
   assert(debugCheckHasMaterialLocalizations(context));
@@ -29,6 +30,7 @@ Future<T?> showMaterialModalBottomSheet<T>({
       .push(ModalSheetRoute<T>(
     builder: builder,
     closeProgressThreshold: closeProgressThreshold,
+    preventPopThreshold: preventPopThreshold,
     containerBuilder: _materialContainerBuilder(
       context,
       backgroundColor: backgroundColor,


### PR DESCRIPTION
- be able to configure `preventPopThreshold`.

- `PopScope` widget within the bottom sheet should be closed by dragging when it's popped.